### PR TITLE
Set pdf_use_win32_gdi to true

### DIFF
--- a/args/windows.args.gn
+++ b/args/windows.args.gn
@@ -11,4 +11,4 @@ pdf_enable_v8 = false
 pdf_enable_xfa = false
 
 # Enable experimental win32 GDI APIs.
-pdf_use_win32_gdi_override = true
+pdf_use_win32_gdi = true


### PR DESCRIPTION
Changes the windows argument name `pdf_use_win32_gdi_override`  to `pdf_use_win32_gdi`, which enables the experimental GDI text rendering API. Fixes #11.

I tested this on Appveyor and can confirm using `dumpbin /EXPORTS pdfium.dll.lib` that the resulting binary has the relevant export symbols `FPDF_SetPrintTextWithGDI` and `FPDF_SetTypefaceAccessibleFunc`. Link to the Appveyor build: https://ci.appveyor.com/project/Lukas-W/pdfium-binaries/builds/25534833