### PR TITLE
Add option to build with V8 for javascript support

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -3,6 +3,7 @@
 : CONFIGURATION = Debug | Release
 : PLATFORM = x86 | x64
 : PDFium_BRANCH = master | chromium/3211 | ...
+: PDFium_V8 = enabled
 
 : Input
 set WindowsSDK_DIR=C:\Program Files (x86)\Windows Kits\10\bin\%PLATFORM%
@@ -20,8 +21,11 @@ set PDFium_STAGING_DIR=%CD%\staging
 set PDFium_INCLUDE_DIR=%PDFium_STAGING_DIR%\include
 set PDFium_BIN_DIR=%PDFium_STAGING_DIR%\%PLATFORM%\bin
 set PDFium_LIB_DIR=%PDFium_STAGING_DIR%\%PLATFORM%\lib
-set PDFium_ARTIFACT=%CD%\pdfium-windows-%PLATFORM%.zip
-if "%CONFIGURATION%"=="Debug" set PDFium_ARTIFACT=%CD%\pdfium-windows-%PLATFORM%-debug.zip
+set PDFium_RES_DIR=%PDFium_STAGING_DIR%\%PLATFORM%\res
+set PDFium_ARTIFACT_BASE=%CD%\pdfium-windows-%PLATFORM%
+if "%PDFium_V8%"=="enabled" set PDFium_ARTIFACT_BASE=%PDFium_ARTIFACT_BASE%-v8
+if "%CONFIGURATION%"=="Debug" set PDFium_ARTIFACT_BASE=%PDFium_ARTIFACT_BASE%-debug
+set PDFium_ARTIFACT=%PDFium_ARTIFACT_BASE%.zip
 
 echo on
 
@@ -33,7 +37,7 @@ mkdir %PDFium_LIB_DIR%
 
 : Download depot_tools
 call curl -fsSL -o depot_tools.zip %DepotTools_URL% || exit /b
-call 7z -bd x depot_tools.zip -o%DepotTools_DIR% || exit /b
+call 7z -bd -y x depot_tools.zip -o%DepotTools_DIR% || exit /b
 set PATH=%DepotTools_DIR%;%WindowsSDK_DIR%;%PATH%
 set DEPOT_TOOLS_WIN_TOOLCHAIN=0
 
@@ -54,12 +58,15 @@ cd %PDFium_SOURCE_DIR%
 copy "%PDFium_PATCH_DIR%\resources.rc" . || exit /b
 git.exe apply -v "%PDFium_PATCH_DIR%\shared_library.patch" || exit /b
 git.exe apply -v "%PDFium_PATCH_DIR%\relative_includes.patch" || exit /b
+if "%PDFium_V8%"=="enabled" git.exe apply -v "%PDFium_PATCH_DIR%\v8_init.patch" || exit /b
 git.exe -C build apply -v "%PDFium_PATCH_DIR%\rc_compiler.patch" || exit /b
 
 : Configure
 copy %PDFium_ARGS% %PDFium_BUILD_DIR%\args.gn
 if "%CONFIGURATION%"=="Release" echo is_debug=false >> %PDFium_BUILD_DIR%\args.gn
 if "%PLATFORM%"=="x86" echo target_cpu="x86" >> %PDFium_BUILD_DIR%\args.gn
+if "%PDFium_V8%"=="enabled" echo pdf_enable_v8=true >> %PDFium_BUILD_DIR%\args.gn
+if "%PDFium_V8%"=="enabled" echo pdf_enable_xfa=true >> %PDFium_BUILD_DIR%\args.gn
 
 : Generate Ninja files
 call gn gen %PDFium_BUILD_DIR% || exit /b
@@ -78,6 +85,11 @@ del %PDFium_INCLUDE_DIR%\PRESUBMIT.py
 move %PDFium_BUILD_DIR%\pdfium.dll.lib %PDFium_LIB_DIR% || exit /b
 move %PDFium_BUILD_DIR%\pdfium.dll %PDFium_BIN_DIR% || exit /b
 if "%CONFIGURATION%"=="Debug" move %PDFium_BUILD_DIR%\pdfium.dll.pdb %PDFium_BIN_DIR%
+if "%PDFium_V8%"=="enabled" (
+    mkdir %PDFium_RES_DIR%
+    move %PDFium_BUILD_DIR%\icudtl.dat %PDFium_RES_DIR%
+    move %PDFium_BUILD_DIR%\snapshot_blob.bin %PDFium_RES_DIR%
+)
 
 : Pack
 cd %PDFium_STAGING_DIR%

--- a/patches/v8_init.patch
+++ b/patches/v8_init.patch
@@ -1,0 +1,71 @@
+diff --git a/fpdfsdk/BUILD.gn b/fpdfsdk/BUILD.gn
+index 3c1b39cba..7a6458796 100644
+--- a/fpdfsdk/BUILD.gn
++++ b/fpdfsdk/BUILD.gn
+@@ -67,6 +67,7 @@ source_set("fpdfsdk") {
+     "fpdf_transformpage.cpp",
+     "fpdf_view.cpp",
+     "ipdfsdk_annothandler.h",
++    "fpdf_libs.cpp",
+   ]
+ 
+   configs += [ "../:pdfium_core_config" ]
+diff --git a/fpdfsdk/fpdf_libs.cpp b/fpdfsdk/fpdf_libs.cpp
+new file mode 100644
+index 000000000..144781857
+--- /dev/null
++++ b/fpdfsdk/fpdf_libs.cpp
+@@ -0,0 +1,22 @@
++#include "public/fpdfview.h"
++
++#include "v8.h"
++
++extern "C"
++{
++
++FPDF_EXPORT void FPDF_CALLCONV FPDF_InitEmbeddedLibraries(const char* resourcePath)
++{
++    v8::V8::InitializeICU();
++
++    v8::V8::InitializeExternalStartupData(resourcePath);
++
++    v8::V8::Initialize();
++
++    // By enabling predictable mode, V8 won't post any background tasks.
++    const char predictable_flag[] = "--predictable";
++    v8::V8::SetFlagsFromString(predictable_flag,
++                                static_cast<int>(strlen(predictable_flag)));
++}
++
++} // extern "C"
+diff --git a/public/fpdf_libs.h b/public/fpdf_libs.h
+new file mode 100644
+index 000000000..5531aba1f
+--- /dev/null
++++ b/public/fpdf_libs.h
+@@ -0,0 +1,25 @@
++#ifndef FPDF_LIBS_H_
++#define FPDF_LIBS_H_
++
++#include "fpdfview.h"
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++// Function: FPDF_InitEmbeddedLibraries
++//          Initialize embedded libraries (v8, iuctl) included in pdfium
++// Parameters:
++//          resourcePath - a path to v8 resources (snapshot_blob.bin, icudtl.dat, ...)
++// Return value:
++//          None.
++// Comments:
++//          This function must be called before calling FPDF_InitLibrary()
++//          if v8 suppport is enabled
++FPDF_EXPORT void FPDF_CALLCONV FPDF_InitEmbeddedLibraries(const char* resourcePath);
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif // FPDF_LIBS_H_


### PR DESCRIPTION
XFA is also enabled.

In order to make it easier for a consuming application a new method
`FPDF_InitEmbeddedLibraries(char* resPath)` is added.
This initializes v8 and other required libraries without the need to include any v8 headers (or assume v8 knowledge on the users side) when using the binaries.

A `-v8` is appended to the archive filename to differentiate from the default build option.

I know that according to #18 the build with v8 enabled breaks appveyor and travis-ci time limits. But maybe you could ask them for an extended timeout. Apart from that having the optional support in the build scripts is probably still useful for local usage.