### PR TITLE
Document V8 initialization and change macOS deployment target

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,35 @@ Here are the download links for latest release:
 
 5. On Windows, make sure that `pdfium.dll` can be found by your executable.
 
+### How to use JavaScript V8 enabled binaries
+
+If you are using the V8 enabled binaries additional initialization is required.
+In your code before using PDFium you have to call `FPDF_InitEmbeddedLibraries()`
+from the additional header `fpdf_libs.h` which is only available in V8 enabled
+binaries.
+
+The archive will contain a `res` folder which you have to distribute with your
+application. On macOS you should include this in your application bundle for other
+platforms place it where your application binary will find it.
+
+See the following example for usage:
+
+        #include "fpdf_libs.h"
+
+        ...
+
+        // Determine the path to files in the res folder from the archive
+        const char* resPath = "<path to the res folder>";
+
+        // Initialize V8 and other embedded libraries
+        FPDF_InitEmbeddedLibraries(resPath);
+
+        // Make use of PDFium
+        FPDF_InitLibrary();
+        FPDF_DestroyLibrary();
+
+
+
 ---
 
 This project isn't affilated with Google nor Foxit.

--- a/build.sh
+++ b/build.sh
@@ -73,6 +73,7 @@ cp "$PDFium_ARGS" "$PDFium_BUILD_DIR/args.gn"
 [ "$CONFIGURATION" == "Release" ] && echo 'is_debug=false' >> "$PDFium_BUILD_DIR/args.gn"
 [ "$PDFium_V8" == "enabled" ] && echo 'pdf_enable_v8=true' >> "$PDFium_BUILD_DIR/args.gn"
 [ "$PDFium_V8" == "enabled" ] && echo 'pdf_enable_xfa=true' >> "$PDFium_BUILD_DIR/args.gn"
+[ "$OS" == "darwin" ] && echo 'mac_deployment_target = "10.9.0"' >> "$PDFium_BUILD_DIR/args.gn"
 
 # Generate Ninja files
 gn gen "$PDFium_BUILD_DIR"


### PR DESCRIPTION
Add a  _How to use JavaScript V8 enabled binaries_ section to the readme

Lower macOS deployment target to 10.9 from the default 10.10.
