### PR TITLE
Fixed hyperlink to Windows NuGet package

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ The following NuGet packages are available:
 
   <tr>
     <td>Windows</td>
-    <td><a href="https://www.nuget.org/packages/bblanchon.PDFium.Windows/">bblanchon.PDFium.Windows</a></td>
+    <td><a href="https://www.nuget.org/packages/bblanchon.PDFium.Win32/">bblanchon.PDFium.Win32</a></td>
   </tr>
 </table>
 


### PR DESCRIPTION
Just fixing the hyperlink for `bblanchon.PDFium.Win32`.