### PR TITLE
Remove deprecated windows config flag

### DIFF
--- a/steps/05-configure.sh
+++ b/steps/05-configure.sh
@@ -27,9 +27,6 @@ mkdir -p "$BUILD"
     mac)
       echo 'mac_deployment_target = "10.13.0"'
       ;;
-    win)
-      echo 'pdf_use_win32_gdi = true'
-      ;;
     wasm):
       echo 'pdf_is_complete_lib = true'
       echo 'is_clang = false'


### PR DESCRIPTION
As you can see [in previous runs](https://github.com/bblanchon/pdfium-binaries/actions/runs/3407953927/jobs/5668082790#step:9:40), `pdf_use_win32_gdi` is deprecated and takes no effect anymore.