### PR TITLE
Update NuGet targets file for .NET Framework 4.8.1 and win-arm64

### DIFF
--- a/nuget/bblanchon.PDFium.Win32.targets
+++ b/nuget/bblanchon.PDFium.Win32.targets
@@ -2,15 +2,20 @@
 <!-- this forces .NET Framework targets to copy the native pdfium assemblies -->
 <!-- .NET (Core) supports the runtimes folder out of the box -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup Condition="'$(TargetFramework)'=='net461' or '$(TargetFramework)'=='net462' or '$(TargetFramework)'=='net47' or '$(TargetFramework)'=='net471' or '$(TargetFramework)'=='net472' or '$(TargetFramework)'=='net48' or '$(TargetFrameworkVersion)'=='v4.6.1' or '$(TargetFrameworkVersion)'=='v4.6.2' or '$(TargetFrameworkVersion)'=='v4.7' or '$(TargetFrameworkVersion)'=='v4.7.1' or '$(TargetFrameworkVersion)'=='v4.7.2' or '$(TargetFrameworkVersion)'=='v4.8'">
+  <ItemGroup Condition="'$(TargetFramework)'=='net461' or '$(TargetFramework)'=='net462' or '$(TargetFramework)'=='net47' or '$(TargetFramework)'=='net471' or '$(TargetFramework)'=='net472' or '$(TargetFramework)'=='net48' or '$(TargetFramework)'=='net481' or '$(TargetFrameworkVersion)'=='v4.6.1' or '$(TargetFrameworkVersion)'=='v4.6.2' or '$(TargetFrameworkVersion)'=='v4.7' or '$(TargetFrameworkVersion)'=='v4.7.1' or '$(TargetFrameworkVersion)'=='v4.7.2' or '$(TargetFrameworkVersion)'=='v4.8' or '$(TargetFrameworkVersion)'=='v4.8.1'">
     <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x86\native\pdfium.dll" >
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>runtimes\win-x86\native\pdfium.dll</Link>
+      <Link>x86\pdfium.dll</Link>
       <Visible>false</Visible>
     </None>
     <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\pdfium.dll">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>runtimes\win-x64\native\pdfium.dll</Link>
+      <Link>x64\pdfium.dll</Link>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-arm64\native\pdfium.dll">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>arm64\pdfium.dll</Link>
       <Visible>false</Visible>
     </None>
   </ItemGroup>


### PR DESCRIPTION
The NuGet file `bblanchon.PDFium.Win32.targets` is for telling the older/deprecated .NET Framework projects where to copy the PDFium binaries. The newer and currently supported .NET is not affected by this change.

1. Microsoft released .NET Framework 4.8.1.
2. net481 adds support for Windows on ARM so the PDFium win-arm64 binary should be copied.
3. Changed the folder structure to match [SkiaSharp.NativeAssets.Win32](https://www.nuget.org/packages/SkiaSharp.NativeAssets.Win32).
E.g. `runtimes\win-x64\native\pdfium.dll` becomes `x64\pdfium.dll`.