### PR TITLE
Remove ref to foxit docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,10 +201,6 @@ I can provide packages for your favorite package manager, but I need help from s
 
 ## Documentation
 
-### PDFium API documentation
-
-Please find the [documentation of the PDFium API on developers.foxit.com](https://developers.foxit.com/resources/pdf-sdk/c_api_reference_pdfium/index.html).
-
 ### How to use PDFium in a CMake project
 
 1. Unzip the downloaded package in a folder (e.g., `C:\Libraries\pdfium`)


### PR DESCRIPTION
The link is down. These docs were outdated and partly misleading in any case. Current pdfium docs are available in the headers, but sadly they do not follow any standard format yet, so it's not possible to generate HTML docs.