### PR TITLE
Support for static linking in ASP.NET Core Blazor WebAssembly

### DIFF
--- a/nuget/bblanchon.PDFium.WebAssembly.nuspec
+++ b/nuget/bblanchon.PDFium.WebAssembly.nuspec
@@ -12,14 +12,29 @@
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>
     <copyright>Copyright © Benoit Blanchon 2017-2022</copyright>
-    <tags>PDFium PDF binaries library native Chromium</tags>
+    <tags>PDFium PDF binaries library native Chromium wasm webassembly</tags>
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFium.WebAssembly.png</iconUrl>
+
+    <dependencies>
+      <group targetFramework="netstandard1.0" />
+    </dependencies>
   </metadata>
 
   <files>
     <file src="bblanchon.PDFium.WebAssembly.png" target="icon.png" />
+
+    <!-- placeholder file because this package contains native binaries only -->
+    <!-- https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5127 -->
+    <file src="_._" target="lib/netstandard1.0/_._" />
+
+    <!-- WebAssembly-specific dependencies aren't referenced automatically and must be referenced manually as NativeFileReferences. -->
+    <!-- Package authors can choose to add the native references by including a .props file in the package with the references. -->
+    <!-- https://learn.microsoft.com/en-us/aspnet/core/blazor/webassembly-native-dependencies#package-native-dependencies-in-a-nuget-package -->
+    <file src="pdfium-wasm/lib/libpdfium.a" target="build/netstandard1.0/libpdfium.a" />
+    <file src="bblanchon.PDFium.WebAssembly.props" target="build/netstandard1.0/bblanchon.PDFium.WebAssembly.props" />
+    <file src="bblanchon.PDFium.WebAssembly.props" target="buildTransitive/netstandard1.0/bblanchon.PDFium.WebAssembly.props" />
 
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->

--- a/nuget/bblanchon.PDFium.WebAssembly.props
+++ b/nuget/bblanchon.PDFium.WebAssembly.props
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <NativeFileReference Include="$(MSBuildThisFileDirectory)..\..\build\netstandard1.0\libpdfium.a" />
+  </ItemGroup>
+</Project>

--- a/steps/07-stage.sh
+++ b/steps/07-stage.sh
@@ -37,6 +37,7 @@ case "$OS" in
     mv "$BUILD/pdfium.html" "$STAGING_LIB"
     mv "$BUILD/pdfium.js" "$STAGING_LIB"
     mv "$BUILD/pdfium.wasm" "$STAGING_LIB"
+    mv "$BUILD/obj/libpdfium.a" "$STAGING_LIB"
     rm -rf "$STAGING/include/cpp"
     rm "$STAGING/PDFiumConfig.cmake"
     ;;


### PR DESCRIPTION
ASP.NET Core Blazor WebAssembly needs `pdfium/out/obj/libpdfium.a` to statically link PDFium into a project. This PR changes the workflow and nuspec to accomplish this.

- The build artifact `pdfium-wasm.tgz` includes `libpdfium.a` now.
- `bblanchon.PDFium.WebAssembly.nuspec` includes `libpdfium.a` as well.
  - The NuGet package structure follows [SkiaSharp.NativeAssets.WebAssembly](https://www.nuget.org/packages/SkiaSharp.NativeAssets.WebAssembly).
- Automatically adds `NativeFileReference` via a prop file.
  - >WebAssembly-specific dependencies aren't referenced automatically and must be referenced manually as `NativeFileReference`s. Package authors can choose to add the native references by including a `.props` file in the package with the references.
  - See [Package native dependencies in a NuGet package](https://learn.microsoft.com/en-us/aspnet/core/blazor/webassembly-native-dependencies#package-native-dependencies-in-a-nuget-package).
- `pdfium.wasm` is still included in the NuGet package for previous use cases (see #94).
- Add `wasm` to the NuGet tag list because searching for "pdfium wasm" on nuget.org yields no results. :-)
- This solves #122 and @jerbob92's input on this PR is very much appreciated.

### Considerations
The pdfium tgz archives should contain platform and architecture specific PDFium binaries. Putting `libpdfium.a` into `pdfium-wasm.tgz` feels wrong but it is needed for static linking via `wasm-ld`. Maybe this should be put into a separate archive? Or maybe it shouldn't be archived at all and be available for the NuGet packaging only.