### PR TITLE
Add header and lib files to NuGet packages

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -517,6 +517,9 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: nuget
+      - name: Prepare header files
+        shell: bash
+        run: xcopy nuget\pdfium-win-x86\include nuget\include\pdfium\ /E
       - name: Pack
         shell: bash
         run: |

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -518,9 +518,8 @@ jobs:
         with:
           path: nuget
       - name: Prepare header files
-        shell: pwsh
-        run: |
-            xcopy nuget\pdfium-win-x86\include nuget\include\pdfium\ /E /Y
+        shell: bash
+        run: mkdir -p nuget/include/pdfium && cp -r nuget/pdfium-win-x86/include nuget/include/pdfium
       - name: Pack
         shell: bash
         run: |

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -519,7 +519,7 @@ jobs:
           path: nuget
       - name: Prepare header files
         shell: bash
-        run: mkdir -p nuget/include/pdfium && cp -r nuget/pdfium-win-x86/include nuget/include/pdfium
+        run: mkdir -p nuget/include/pdfium && cp -r nuget/pdfium-win-x86/include/* nuget/include/pdfium/
       - name: Pack
         shell: bash
         run: |

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -518,8 +518,9 @@ jobs:
         with:
           path: nuget
       - name: Prepare header files
-        shell: bash
-        run: xcopy nuget\pdfium-win-x86\include nuget\include\pdfium\ /E
+        shell: pwsh
+        run: |
+            xcopy nuget\pdfium-win-x86\include nuget\include\pdfium\ /E /Y
       - name: Pack
         shell: bash
         run: |

--- a/nuget/bblanchon.PDFium.Android.nuspec
+++ b/nuget/bblanchon.PDFium.Android.nuspec
@@ -16,6 +16,7 @@
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFium.Android.png</iconUrl>
+    <readme>README.md</readme>
 
     <dependencies>
       <group targetFramework="MonoAndroid1.0" />
@@ -25,6 +26,7 @@
 
   <files>
     <file src="bblanchon.PDFium.Android.png" target="icon.png" />
+    <file src="../README.md" target="README.md" />
 
     <!-- placeholder files because this package contains native binaries only -->
     <!-- https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5127 -->

--- a/nuget/bblanchon.PDFium.Android.nuspec
+++ b/nuget/bblanchon.PDFium.Android.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <copyright>Copyright © Benoit Blanchon 2017-2022</copyright>
+    <copyright>Copyright © Benoit Blanchon 2017-2023</copyright>
     <tags>PDFium PDF binaries library native Chromium</tags>
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>

--- a/nuget/bblanchon.PDFium.Android.nuspec
+++ b/nuget/bblanchon.PDFium.Android.nuspec
@@ -7,7 +7,6 @@
     <owners>Benoit Blanchon</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
-    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>

--- a/nuget/bblanchon.PDFium.Android.nuspec
+++ b/nuget/bblanchon.PDFium.Android.nuspec
@@ -18,7 +18,9 @@
     <readme>README.md</readme>
 
     <dependencies>
-      <group targetFramework="MonoAndroid1.0" />
+      <group targetFramework="native" />
+      <group targetFramework="netstandard1.0" />
+      <group targetFramework="monoandroid1.0" />
       <group targetFramework="net6.0-android21.0" />
     </dependencies>
   </metadata>
@@ -27,6 +29,10 @@
     <file src="bblanchon.PDFium.Android.png" target="icon.png" />
     <file src="../README.md" target="README.md" />
 
+    <!-- https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128 -->
+    <file src="_._" target="lib/native/_._" />
+    <file src="_._" target="lib/netstandard1.0/_._" />
+    
     <!-- placeholder files because this package contains native binaries only -->
     <!-- https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5127 -->
     <file src="_._" target="lib/monoandroid1.0/_._" />

--- a/nuget/bblanchon.PDFium.Android.nuspec
+++ b/nuget/bblanchon.PDFium.Android.nuspec
@@ -38,6 +38,10 @@
     <file src="bblanchon.PDFium.Android.targets" target="build/monoandroid1.0/bblanchon.PDFium.Android.targets" />
     <file src="bblanchon.PDFium.Android.targets" target="buildTransitive/monoandroid1.0/bblanchon.PDFium.Android.targets" />
 
+    <!-- include hearder and lib files for C++ projects -->
+    <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFium.Android.targets" />
+    <file src="include/**/*.h" target="build/native" />
+
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->
     <!-- https://docs.microsoft.com/en-us/dotnet/core/rid-catalog -->

--- a/nuget/bblanchon.PDFium.Linux.nuspec
+++ b/nuget/bblanchon.PDFium.Linux.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <copyright>Copyright © Benoit Blanchon 2017-2022</copyright>
+    <copyright>Copyright © Benoit Blanchon 2017-2023</copyright>
     <tags>PDFium PDF binaries library native Chromium</tags>
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>

--- a/nuget/bblanchon.PDFium.Linux.nuspec
+++ b/nuget/bblanchon.PDFium.Linux.nuspec
@@ -16,10 +16,12 @@
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFium.Linux.png</iconUrl>
+    <readme>README.md</readme>
   </metadata>
 
   <files>
     <file src="bblanchon.PDFium.Linux.png" target="icon.png" />
+    <file src="../README.md" target="README.md" />
 
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->

--- a/nuget/bblanchon.PDFium.Linux.nuspec
+++ b/nuget/bblanchon.PDFium.Linux.nuspec
@@ -7,7 +7,6 @@
     <owners>Benoit Blanchon</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
-    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>

--- a/nuget/bblanchon.PDFium.Linux.nuspec
+++ b/nuget/bblanchon.PDFium.Linux.nuspec
@@ -23,6 +23,10 @@
     <file src="bblanchon.PDFium.Linux.png" target="icon.png" />
     <file src="../README.md" target="README.md" />
 
+    <!-- include hearder and lib files for C++ projects -->
+    <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFium.Linux.targets" />
+    <file src="include/**/*.h" target="build/native" />
+
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->
     <!-- https://docs.microsoft.com/en-us/dotnet/core/rid-catalog -->

--- a/nuget/bblanchon.PDFium.Linux.nuspec
+++ b/nuget/bblanchon.PDFium.Linux.nuspec
@@ -16,11 +16,20 @@
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFium.Linux.png</iconUrl>
     <readme>README.md</readme>
+
+    <dependencies>
+      <group targetFramework="native" />
+      <group targetFramework="netstandard1.0" />
+    </dependencies>
   </metadata>
 
   <files>
     <file src="bblanchon.PDFium.Linux.png" target="icon.png" />
     <file src="../README.md" target="README.md" />
+
+    <!-- https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128 -->
+    <file src="_._" target="lib/native/_._" />
+    <file src="_._" target="lib/netstandard1.0/_._" />
 
     <!-- include hearder and lib files for C++ projects -->
     <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFium.Linux.targets" />

--- a/nuget/bblanchon.PDFium.WebAssembly.nuspec
+++ b/nuget/bblanchon.PDFium.WebAssembly.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <copyright>Copyright © Benoit Blanchon 2017-2022</copyright>
+    <copyright>Copyright © Benoit Blanchon 2017-2023</copyright>
     <tags>PDFium PDF binaries library native Chromium wasm webassembly</tags>
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>

--- a/nuget/bblanchon.PDFium.WebAssembly.nuspec
+++ b/nuget/bblanchon.PDFium.WebAssembly.nuspec
@@ -18,6 +18,7 @@
     <readme>README.md</readme>
 
     <dependencies>
+      <group targetFramework="native" />
       <group targetFramework="netstandard1.0" />
     </dependencies>
   </metadata>
@@ -25,9 +26,9 @@
   <files>
     <file src="bblanchon.PDFium.WebAssembly.png" target="icon.png" />
     <file src="../README.md" target="README.md" />
-
-    <!-- placeholder file because this package contains native binaries only -->
-    <!-- https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5127 -->
+    
+    <!-- https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128 -->
+    <file src="_._" target="lib/native/_._" />
     <file src="_._" target="lib/netstandard1.0/_._" />
 
     <!-- WebAssembly-specific dependencies aren't referenced automatically and must be referenced manually as NativeFileReferences. -->

--- a/nuget/bblanchon.PDFium.WebAssembly.nuspec
+++ b/nuget/bblanchon.PDFium.WebAssembly.nuspec
@@ -7,7 +7,6 @@
     <owners>Benoit Blanchon</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
-    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>

--- a/nuget/bblanchon.PDFium.WebAssembly.nuspec
+++ b/nuget/bblanchon.PDFium.WebAssembly.nuspec
@@ -38,6 +38,10 @@
     <file src="bblanchon.PDFium.WebAssembly.props" target="build/netstandard1.0/bblanchon.PDFium.WebAssembly.props" />
     <file src="bblanchon.PDFium.WebAssembly.props" target="buildTransitive/netstandard1.0/bblanchon.PDFium.WebAssembly.props" />
 
+    <!-- include hearder and lib files for C++ projects -->
+    <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFium.WebAssembly.targets" />
+    <file src="include/**/*.h" target="build/native" />
+
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->
     <!-- https://docs.microsoft.com/en-us/dotnet/core/rid-catalog -->

--- a/nuget/bblanchon.PDFium.WebAssembly.nuspec
+++ b/nuget/bblanchon.PDFium.WebAssembly.nuspec
@@ -16,6 +16,7 @@
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFium.WebAssembly.png</iconUrl>
+    <readme>README.md</readme>
 
     <dependencies>
       <group targetFramework="netstandard1.0" />
@@ -24,6 +25,7 @@
 
   <files>
     <file src="bblanchon.PDFium.WebAssembly.png" target="icon.png" />
+    <file src="../README.md" target="README.md" />
 
     <!-- placeholder file because this package contains native binaries only -->
     <!-- https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5127 -->

--- a/nuget/bblanchon.PDFium.Win32.native.targets
+++ b/nuget/bblanchon.PDFium.Win32.native.targets
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- this target file adds support for C++ projects -->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemDefinitionGroup>
+    <!-- include pdfium lib files -->
+    <Link>
+      <AdditionalDependencies Condition="'$(Platform)' == 'arm64'">$(MSBuildThisFileDirectory)lib\win-arm64\pdfium.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)lib\win-x64\pdfium.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Platform)' == 'x86'">$(MSBuildThisFileDirectory)lib\win-x86\pdfium.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories Condition="'$(Platform)' == 'arm64'">$(MSBuildThisFileDirectory)lib\win-arm64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)lib\win-x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Platform)' == 'x86'">$(MSBuildThisFileDirectory)lib\win-x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+
+    <!-- include pdfium header files -->
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+
+  <!-- include pdfium native binaries -->
+  <ItemGroup Condition="'$(Platform)' == 'arm64'">
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-arm64\native\pdfium.dll" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Platform)' == 'x64'">
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\pdfium.dll" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(Platform)' == 'x86'">
+    <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x86\native\pdfium.dll" />
+  </ItemGroup>
+</Project>

--- a/nuget/bblanchon.PDFium.Win32.native.targets
+++ b/nuget/bblanchon.PDFium.Win32.native.targets
@@ -6,10 +6,10 @@
     <Link>
       <AdditionalDependencies Condition="'$(Platform)' == 'arm64'">$(MSBuildThisFileDirectory)lib\win-arm64\pdfium.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)lib\win-x64\pdfium.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Platform)' == 'x86'">$(MSBuildThisFileDirectory)lib\win-x86\pdfium.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Platform)' != 'arm64' and '$(Platform)' != 'x64'">$(MSBuildThisFileDirectory)lib\win-x86\pdfium.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories Condition="'$(Platform)' == 'arm64'">$(MSBuildThisFileDirectory)lib\win-arm64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalLibraryDirectories Condition="'$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)lib\win-x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalLibraryDirectories Condition="'$(Platform)' == 'x86'">$(MSBuildThisFileDirectory)lib\win-x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Platform)' != 'arm64' and '$(Platform)' != 'x64'">$(MSBuildThisFileDirectory)lib\win-x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
 
     <!-- include pdfium header files -->
@@ -27,7 +27,7 @@
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\pdfium.dll" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Platform)' == 'x86'">
+  <ItemGroup Condition="'$(Platform)' != 'arm64' and '$(Platform)' != 'x64'">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x86\native\pdfium.dll" />
   </ItemGroup>
 </Project>

--- a/nuget/bblanchon.PDFium.Win32.native.targets
+++ b/nuget/bblanchon.PDFium.Win32.native.targets
@@ -5,11 +5,11 @@
     <!-- include pdfium lib files -->
     <Link>
       <AdditionalDependencies Condition="'$(Platform)' == 'arm64'">$(MSBuildThisFileDirectory)lib\win-arm64\pdfium.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)lib\win-x64\pdfium.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Platform)' != 'arm64' and '$(Platform)' != 'x64'">$(MSBuildThisFileDirectory)lib\win-x86\pdfium.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Platform)' == 'x64' or '$(Platform)' == 'arm64ec'">$(MSBuildThisFileDirectory)lib\win-x64\pdfium.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Platform)' != 'arm64' and '$(Platform)' != 'arm64ec' and '$(Platform)' != 'x64'">$(MSBuildThisFileDirectory)lib\win-x86\pdfium.dll.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories Condition="'$(Platform)' == 'arm64'">$(MSBuildThisFileDirectory)lib\win-arm64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalLibraryDirectories Condition="'$(Platform)' == 'x64'">$(MSBuildThisFileDirectory)lib\win-x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalLibraryDirectories Condition="'$(Platform)' != 'arm64' and '$(Platform)' != 'x64'">$(MSBuildThisFileDirectory)lib\win-x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Platform)' == 'x64' or '$(Platform)' == 'arm64ec'">$(MSBuildThisFileDirectory)lib\win-x64;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories Condition="'$(Platform)' != 'arm64' and '$(Platform)' != 'arm64ec' and '$(Platform)' != 'x64'">$(MSBuildThisFileDirectory)lib\win-x86;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
 
     <!-- include pdfium header files -->
@@ -23,11 +23,11 @@
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-arm64\native\pdfium.dll" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Platform)' == 'x64'">
+  <ItemGroup Condition="'$(Platform)' == 'x64' or '$(Platform)' == 'arm64ec'">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\pdfium.dll" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(Platform)' != 'arm64' and '$(Platform)' != 'x64'">
+  <ItemGroup Condition="'$(Platform)' != 'arm64' and '$(Platform)' != 'arm64ec' and '$(Platform)' != 'x64'">
     <ReferenceCopyLocalPaths Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x86\native\pdfium.dll" />
   </ItemGroup>
 </Project>

--- a/nuget/bblanchon.PDFium.Win32.nuspec
+++ b/nuget/bblanchon.PDFium.Win32.nuspec
@@ -18,6 +18,7 @@
     <readme>README.md</readme>
 
     <dependencies>
+      <group targetFramework="native" />
       <group targetFramework="netstandard2.0" />
     </dependencies>
   </metadata>
@@ -25,6 +26,9 @@
   <files>
     <file src="bblanchon.PDFium.Win32.png" target="icon.png" />
     <file src="../README.md" target="README.md" />
+
+    <!-- https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128 -->
+    <file src="_._" target="lib/native/_._" />
 
     <!-- placeholder file because this package contains native binaries only -->
     <!-- we want to fail on any platform not compatible with .NET Standard 2.0 (on Windows only) -->

--- a/nuget/bblanchon.PDFium.Win32.nuspec
+++ b/nuget/bblanchon.PDFium.Win32.nuspec
@@ -7,7 +7,6 @@
     <owners>Benoit Blanchon</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
-    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>

--- a/nuget/bblanchon.PDFium.Win32.nuspec
+++ b/nuget/bblanchon.PDFium.Win32.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <copyright>Copyright © Benoit Blanchon 2017-2022</copyright>
+    <copyright>Copyright © Benoit Blanchon 2017-2023</copyright>
     <tags>PDFium PDF binaries library native Chromium</tags>
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>
@@ -34,6 +34,13 @@
     <!-- .NET (Core) does not need this and handles the runtimes folder on its own -->
     <file src="bblanchon.PDFium.Win32.targets" target="build/net461/bblanchon.PDFium.Win32.targets" />
     <file src="bblanchon.PDFium.Win32.targets" target="buildTransitive/net461/bblanchon.PDFium.Win32.targets" />
+
+    <!-- include hearder and lib files for C++ projects -->
+    <file src="bblanchon.PDFium.Win32.native.targets" target="build/native/bblanchon.PDFium.Win32.native.targets" />
+    <file src="pdfium-win-arm64/lib/pdfium.dll.lib" target="build/native/lib/win-arm64/pdfium.dll.lib" />
+    <file src="pdfium-win-x64/lib/pdfium.dll.lib" target="build/native/lib/win-x64/pdfium.dll.lib" />
+    <file src="pdfium-win-x86/lib/pdfium.dll.lib" target="build/native/lib/win-x86/pdfium.dll.lib" />
+    <file src="pdfium-win-x86/include/*.h" target="build/native/include" />
 
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->

--- a/nuget/bblanchon.PDFium.Win32.nuspec
+++ b/nuget/bblanchon.PDFium.Win32.nuspec
@@ -16,6 +16,7 @@
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFium.Win32.png</iconUrl>
+    <readme>README.md</readme>
 
     <dependencies>
       <group targetFramework="netstandard2.0" />
@@ -24,6 +25,7 @@
 
   <files>
     <file src="bblanchon.PDFium.Win32.png" target="icon.png" />
+    <file src="../README.md" target="README.md" />
 
     <!-- placeholder file because this package contains native binaries only -->
     <!-- we want to fail on any platform not compatible with .NET Standard 2.0 (on Windows only) -->
@@ -36,11 +38,11 @@
     <file src="bblanchon.PDFium.Win32.targets" target="buildTransitive/net461/bblanchon.PDFium.Win32.targets" />
 
     <!-- include hearder and lib files for C++ projects -->
-    <file src="bblanchon.PDFium.Win32.native.targets" target="build/native/bblanchon.PDFium.Win32.native.targets" />
+    <file src="bblanchon.PDFium.Win32.native.targets" target="build/native/bblanchon.PDFium.Win32.targets" />
     <file src="pdfium-win-arm64/lib/pdfium.dll.lib" target="build/native/lib/win-arm64/pdfium.dll.lib" />
     <file src="pdfium-win-x64/lib/pdfium.dll.lib" target="build/native/lib/win-x64/pdfium.dll.lib" />
     <file src="pdfium-win-x86/lib/pdfium.dll.lib" target="build/native/lib/win-x86/pdfium.dll.lib" />
-    <file src="pdfium-win-x86/include/*.h" target="build/native/include" />
+    <file src="include/**/*.h" target="build/native" />
 
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->

--- a/nuget/bblanchon.PDFium.iOS.nuspec
+++ b/nuget/bblanchon.PDFium.iOS.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <copyright>Copyright © Benoit Blanchon 2017-2022</copyright>
+    <copyright>Copyright © Benoit Blanchon 2017-2023</copyright>
     <tags>PDFium PDF binaries library native Chromium</tags>
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>

--- a/nuget/bblanchon.PDFium.iOS.nuspec
+++ b/nuget/bblanchon.PDFium.iOS.nuspec
@@ -23,6 +23,10 @@
     <file src="bblanchon.PDFium.iOS.png" target="icon.png" />
     <file src="../README.md" target="README.md" />
 
+    <!-- include hearder and lib files for C++ projects -->
+    <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFium.iOS.targets" />
+    <file src="include/**/*.h" target="build/native" />
+
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->
     <!-- https://docs.microsoft.com/en-us/dotnet/core/rid-catalog -->

--- a/nuget/bblanchon.PDFium.iOS.nuspec
+++ b/nuget/bblanchon.PDFium.iOS.nuspec
@@ -7,7 +7,6 @@
     <owners>Benoit Blanchon</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
-    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>

--- a/nuget/bblanchon.PDFium.iOS.nuspec
+++ b/nuget/bblanchon.PDFium.iOS.nuspec
@@ -16,11 +16,20 @@
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFium.iOS.png</iconUrl>
     <readme>README.md</readme>
+
+    <dependencies>
+      <group targetFramework="native" />
+      <group targetFramework="netstandard1.0" />
+    </dependencies>
   </metadata>
 
   <files>
     <file src="bblanchon.PDFium.iOS.png" target="icon.png" />
     <file src="../README.md" target="README.md" />
+
+    <!-- https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128 -->
+    <file src="_._" target="lib/native/_._" />
+    <file src="_._" target="lib/netstandard1.0/_._" />
 
     <!-- include hearder and lib files for C++ projects -->
     <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFium.iOS.targets" />

--- a/nuget/bblanchon.PDFium.iOS.nuspec
+++ b/nuget/bblanchon.PDFium.iOS.nuspec
@@ -16,10 +16,12 @@
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFium.iOS.png</iconUrl>
+    <readme>README.md</readme>
   </metadata>
 
   <files>
     <file src="bblanchon.PDFium.iOS.png" target="icon.png" />
+    <file src="../README.md" target="README.md" />
 
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->

--- a/nuget/bblanchon.PDFium.macOS.nuspec
+++ b/nuget/bblanchon.PDFium.macOS.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <copyright>Copyright © Benoit Blanchon 2017-2022</copyright>
+    <copyright>Copyright © Benoit Blanchon 2017-2023</copyright>
     <tags>PDFium PDF binaries library native Chromium</tags>
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>

--- a/nuget/bblanchon.PDFium.macOS.nuspec
+++ b/nuget/bblanchon.PDFium.macOS.nuspec
@@ -16,11 +16,20 @@
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFium.macOS.png</iconUrl>
     <readme>README.md</readme>
+
+    <dependencies>
+      <group targetFramework="native" />
+      <group targetFramework="netstandard1.0" />
+    </dependencies>
   </metadata>
 
   <files>
     <file src="bblanchon.PDFium.macOS.png" target="icon.png" />
     <file src="../README.md" target="README.md" />
+
+    <!-- https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128 -->
+    <file src="_._" target="lib/native/_._" />
+    <file src="_._" target="lib/netstandard1.0/_._" />
 
     <!-- include hearder and lib files for C++ projects -->
     <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFium.macOS.targets" />

--- a/nuget/bblanchon.PDFium.macOS.nuspec
+++ b/nuget/bblanchon.PDFium.macOS.nuspec
@@ -7,7 +7,6 @@
     <owners>Benoit Blanchon</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
-    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>

--- a/nuget/bblanchon.PDFium.macOS.nuspec
+++ b/nuget/bblanchon.PDFium.macOS.nuspec
@@ -23,6 +23,10 @@
     <file src="bblanchon.PDFium.macOS.png" target="icon.png" />
     <file src="../README.md" target="README.md" />
 
+    <!-- include hearder and lib files for C++ projects -->
+    <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFium.macOS.targets" />
+    <file src="include/**/*.h" target="build/native" />
+
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->
     <!-- https://docs.microsoft.com/en-us/dotnet/core/rid-catalog -->

--- a/nuget/bblanchon.PDFium.macOS.nuspec
+++ b/nuget/bblanchon.PDFium.macOS.nuspec
@@ -16,10 +16,12 @@
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFium.macOS.png</iconUrl>
+    <readme>README.md</readme>
   </metadata>
 
   <files>
     <file src="bblanchon.PDFium.macOS.png" target="icon.png" />
+    <file src="../README.md" target="README.md" />
 
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->

--- a/nuget/bblanchon.PDFium.native.targets
+++ b/nuget/bblanchon.PDFium.native.targets
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- this target file adds support for C++ projects -->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemDefinitionGroup>
+    <!-- include pdfium header files -->
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/nuget/bblanchon.PDFium.nuspec
+++ b/nuget/bblanchon.PDFium.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <copyright>Copyright © Benoit Blanchon 2017-2022</copyright>
+    <copyright>Copyright © Benoit Blanchon 2017-2023</copyright>
     <tags>PDFium PDF binaries library native Chromium</tags>
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>

--- a/nuget/bblanchon.PDFium.nuspec
+++ b/nuget/bblanchon.PDFium.nuspec
@@ -16,6 +16,8 @@
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFium.png</iconUrl>
+    <readme>README.md</readme>
+
     <dependencies>
       <group>
         <dependency id="bblanchon.PDFium.Android" version="$version$" />
@@ -31,5 +33,6 @@
   <!-- just a meta package without content -->
   <files>
     <file src="bblanchon.PDFium.png" target="icon.png" />
+    <file src="../README.md" target="README.md" />
   </files>
 </package>

--- a/nuget/bblanchon.PDFium.nuspec
+++ b/nuget/bblanchon.PDFium.nuspec
@@ -7,7 +7,6 @@
     <owners>Benoit Blanchon</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
-    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>

--- a/nuget/bblanchon.PDFiumV8.Android.nuspec
+++ b/nuget/bblanchon.PDFiumV8.Android.nuspec
@@ -16,6 +16,7 @@
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFiumV8.Android.png</iconUrl>
+    <readme>README.md</readme>
 
     <dependencies>
       <group targetFramework="MonoAndroid1.0" />
@@ -25,6 +26,7 @@
 
   <files>
     <file src="bblanchon.PDFiumV8.Android.png" target="icon.png" />
+    <file src="../README.md" target="README.md" />
 
     <!-- placeholder files because this package contains native binaries only -->
     <!-- https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5127 -->

--- a/nuget/bblanchon.PDFiumV8.Android.nuspec
+++ b/nuget/bblanchon.PDFiumV8.Android.nuspec
@@ -18,7 +18,9 @@
     <readme>README.md</readme>
 
     <dependencies>
-      <group targetFramework="MonoAndroid1.0" />
+      <group targetFramework="native" />
+      <group targetFramework="netstandard1.0" />
+      <group targetFramework="monoandroid1.0" />
       <group targetFramework="net6.0-android21.0" />
     </dependencies>
   </metadata>
@@ -26,6 +28,10 @@
   <files>
     <file src="bblanchon.PDFiumV8.Android.png" target="icon.png" />
     <file src="../README.md" target="README.md" />
+
+    <!-- https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128 -->
+    <file src="_._" target="lib/native/_._" />
+    <file src="_._" target="lib/netstandard1.0/_._" />
 
     <!-- placeholder files because this package contains native binaries only -->
     <!-- https://docs.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5127 -->

--- a/nuget/bblanchon.PDFiumV8.Android.nuspec
+++ b/nuget/bblanchon.PDFiumV8.Android.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <copyright>Copyright © Benoit Blanchon 2017-2022</copyright>
+    <copyright>Copyright © Benoit Blanchon 2017-2023</copyright>
     <tags>PDFium PDF binaries library native Chromium</tags>
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>

--- a/nuget/bblanchon.PDFiumV8.Android.nuspec
+++ b/nuget/bblanchon.PDFiumV8.Android.nuspec
@@ -7,7 +7,6 @@
     <owners>Benoit Blanchon</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
-    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>

--- a/nuget/bblanchon.PDFiumV8.Android.nuspec
+++ b/nuget/bblanchon.PDFiumV8.Android.nuspec
@@ -38,6 +38,10 @@
     <file src="bblanchon.PDFium.Android.targets" target="build/monoandroid1.0/bblanchon.PDFiumV8.Android.targets" />
     <file src="bblanchon.PDFium.Android.targets" target="buildTransitive/monoandroid1.0/bblanchon.PDFiumV8.Android.targets" />
 
+    <!-- include hearder and lib files for C++ projects -->
+    <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFiumV8.Android.targets" />
+    <file src="include/**/*.h" target="build/native" />
+
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->
     <!-- https://docs.microsoft.com/en-us/dotnet/core/rid-catalog -->

--- a/nuget/bblanchon.PDFiumV8.Linux.nuspec
+++ b/nuget/bblanchon.PDFiumV8.Linux.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <copyright>Copyright © Benoit Blanchon 2017-2022</copyright>
+    <copyright>Copyright © Benoit Blanchon 2017-2023</copyright>
     <tags>PDFium PDF binaries library native Chromium</tags>
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>

--- a/nuget/bblanchon.PDFiumV8.Linux.nuspec
+++ b/nuget/bblanchon.PDFiumV8.Linux.nuspec
@@ -16,11 +16,20 @@
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFiumV8.Linux.png</iconUrl>
     <readme>README.md</readme>
+
+    <dependencies>
+      <group targetFramework="native" />
+      <group targetFramework="netstandard1.0" />
+    </dependencies>
   </metadata>
 
   <files>
     <file src="bblanchon.PDFiumV8.Linux.png" target="icon.png" />
     <file src="../README.md" target="README.md" />
+
+    <!-- https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128 -->
+    <file src="_._" target="lib/native/_._" />
+    <file src="_._" target="lib/netstandard1.0/_._" />
 
     <!-- include hearder and lib files for C++ projects -->
     <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFiumV8.Linux.targets" />

--- a/nuget/bblanchon.PDFiumV8.Linux.nuspec
+++ b/nuget/bblanchon.PDFiumV8.Linux.nuspec
@@ -7,7 +7,6 @@
     <owners>Benoit Blanchon</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
-    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>

--- a/nuget/bblanchon.PDFiumV8.Linux.nuspec
+++ b/nuget/bblanchon.PDFiumV8.Linux.nuspec
@@ -23,6 +23,10 @@
     <file src="bblanchon.PDFiumV8.Linux.png" target="icon.png" />
     <file src="../README.md" target="README.md" />
 
+    <!-- include hearder and lib files for C++ projects -->
+    <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFiumV8.Linux.targets" />
+    <file src="include/**/*.h" target="build/native" />
+
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->
     <!-- https://docs.microsoft.com/en-us/dotnet/core/rid-catalog -->

--- a/nuget/bblanchon.PDFiumV8.Linux.nuspec
+++ b/nuget/bblanchon.PDFiumV8.Linux.nuspec
@@ -16,10 +16,12 @@
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFiumV8.Linux.png</iconUrl>
+    <readme>README.md</readme>
   </metadata>
 
   <files>
     <file src="bblanchon.PDFiumV8.Linux.png" target="icon.png" />
+    <file src="../README.md" target="README.md" />
 
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->

--- a/nuget/bblanchon.PDFiumV8.Win32.nuspec
+++ b/nuget/bblanchon.PDFiumV8.Win32.nuspec
@@ -18,6 +18,7 @@
     <readme>README.md</readme>
 
     <dependencies>
+      <group targetFramework="native" />
       <group targetFramework="netstandard2.0" />
     </dependencies>
   </metadata>
@@ -25,6 +26,9 @@
   <files>
     <file src="bblanchon.PDFiumV8.Win32.png" target="icon.png" />
     <file src="../README.md" target="README.md" />
+
+    <!-- https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128 -->
+    <file src="_._" target="lib/native/_._" />
 
     <!-- placeholder file because this package contains native binaries only -->
     <!-- we want to fail on any platform not compatible with .NET Standard 2.0 (on Windows only) -->

--- a/nuget/bblanchon.PDFiumV8.Win32.nuspec
+++ b/nuget/bblanchon.PDFiumV8.Win32.nuspec
@@ -7,7 +7,6 @@
     <owners>Benoit Blanchon</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
-    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>

--- a/nuget/bblanchon.PDFiumV8.Win32.nuspec
+++ b/nuget/bblanchon.PDFiumV8.Win32.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <copyright>Copyright © Benoit Blanchon 2017-2022</copyright>
+    <copyright>Copyright © Benoit Blanchon 2017-2023</copyright>
     <tags>PDFium PDF binaries library native Chromium</tags>
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>
@@ -34,6 +34,13 @@
     <!-- .NET (Core) does not need this and handles the runtimes folder on its own -->
     <file src="bblanchon.PDFium.Win32.targets" target="build/net461/bblanchon.PDFiumV8.Win32.targets" />
     <file src="bblanchon.PDFium.Win32.targets" target="buildTransitive/net461/bblanchon.PDFiumV8.Win32.targets" />
+
+    <!-- include hearder and lib files for C++ projects -->
+    <file src="bblanchon.PDFium.Win32.native.targets" target="build/native/bblanchon.PDFium.Win32.native.targets" />
+    <file src="pdfium-v8-win-arm64/lib/pdfium.dll.lib" target="build/native/lib/win-arm64/pdfium.dll.lib" />
+    <file src="pdfium-v8-win-x64/lib/pdfium.dll.lib" target="build/native/lib/win-x64/pdfium.dll.lib" />
+    <file src="pdfium-v8-win-x86/lib/pdfium.dll.lib" target="build/native/lib/win-x86/pdfium.dll.lib" />
+    <file src="pdfium-v8-win-x86/include/*.h" target="build/native/include" />
 
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->

--- a/nuget/bblanchon.PDFiumV8.Win32.nuspec
+++ b/nuget/bblanchon.PDFiumV8.Win32.nuspec
@@ -16,6 +16,7 @@
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFiumV8.Win32.png</iconUrl>
+    <readme>README.md</readme>
 
     <dependencies>
       <group targetFramework="netstandard2.0" />
@@ -24,6 +25,7 @@
 
   <files>
     <file src="bblanchon.PDFiumV8.Win32.png" target="icon.png" />
+    <file src="../README.md" target="README.md" />
 
     <!-- placeholder file because this package contains native binaries only -->
     <!-- we want to fail on any platform not compatible with .NET Standard 2.0 (on Windows only) -->
@@ -36,11 +38,11 @@
     <file src="bblanchon.PDFium.Win32.targets" target="buildTransitive/net461/bblanchon.PDFiumV8.Win32.targets" />
 
     <!-- include hearder and lib files for C++ projects -->
-    <file src="bblanchon.PDFium.Win32.native.targets" target="build/native/bblanchon.PDFium.Win32.native.targets" />
+    <file src="bblanchon.PDFium.Win32.native.targets" target="build/native/bblanchon.PDFiumV8.Win32.targets" />
     <file src="pdfium-v8-win-arm64/lib/pdfium.dll.lib" target="build/native/lib/win-arm64/pdfium.dll.lib" />
     <file src="pdfium-v8-win-x64/lib/pdfium.dll.lib" target="build/native/lib/win-x64/pdfium.dll.lib" />
     <file src="pdfium-v8-win-x86/lib/pdfium.dll.lib" target="build/native/lib/win-x86/pdfium.dll.lib" />
-    <file src="pdfium-v8-win-x86/include/*.h" target="build/native/include" />
+    <file src="include/**/*.h" target="build/native" />
 
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->

--- a/nuget/bblanchon.PDFiumV8.iOS.nuspec
+++ b/nuget/bblanchon.PDFiumV8.iOS.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <copyright>Copyright © Benoit Blanchon 2017-2022</copyright>
+    <copyright>Copyright © Benoit Blanchon 2017-2023</copyright>
     <tags>PDFium PDF binaries library native Chromium</tags>
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>

--- a/nuget/bblanchon.PDFiumV8.iOS.nuspec
+++ b/nuget/bblanchon.PDFiumV8.iOS.nuspec
@@ -16,11 +16,20 @@
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFiumV8.iOS.png</iconUrl>
     <readme>README.md</readme>
+
+    <dependencies>
+      <group targetFramework="native" />
+      <group targetFramework="netstandard1.0" />
+    </dependencies>
   </metadata>
 
   <files>
     <file src="bblanchon.PDFiumV8.iOS.png" target="icon.png" />
     <file src="../README.md" target="README.md" />
+    
+    <!-- https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128 -->
+    <file src="_._" target="lib/native/_._" />
+    <file src="_._" target="lib/netstandard1.0/_._" />
 
     <!-- include hearder and lib files for C++ projects -->
     <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFiumV8.iOS.targets" />

--- a/nuget/bblanchon.PDFiumV8.iOS.nuspec
+++ b/nuget/bblanchon.PDFiumV8.iOS.nuspec
@@ -7,7 +7,6 @@
     <owners>Benoit Blanchon</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
-    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>

--- a/nuget/bblanchon.PDFiumV8.iOS.nuspec
+++ b/nuget/bblanchon.PDFiumV8.iOS.nuspec
@@ -23,6 +23,10 @@
     <file src="bblanchon.PDFiumV8.iOS.png" target="icon.png" />
     <file src="../README.md" target="README.md" />
 
+    <!-- include hearder and lib files for C++ projects -->
+    <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFiumV8.iOS.targets" />
+    <file src="include/**/*.h" target="build/native" />
+
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->
     <!-- https://docs.microsoft.com/en-us/dotnet/core/rid-catalog -->

--- a/nuget/bblanchon.PDFiumV8.iOS.nuspec
+++ b/nuget/bblanchon.PDFiumV8.iOS.nuspec
@@ -16,10 +16,12 @@
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFiumV8.iOS.png</iconUrl>
+    <readme>README.md</readme>
   </metadata>
 
   <files>
     <file src="bblanchon.PDFiumV8.iOS.png" target="icon.png" />
+    <file src="../README.md" target="README.md" />
 
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->

--- a/nuget/bblanchon.PDFiumV8.macOS.nuspec
+++ b/nuget/bblanchon.PDFiumV8.macOS.nuspec
@@ -23,6 +23,10 @@
     <file src="bblanchon.PDFiumV8.macOS.png" target="icon.png" />
     <file src="../README.md" target="README.md" />
 
+    <!-- include hearder and lib files for C++ projects -->
+    <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFiumV8.macOS.targets" />
+    <file src="include/**/*.h" target="build/native" />
+
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->
     <!-- https://docs.microsoft.com/en-us/dotnet/core/rid-catalog -->

--- a/nuget/bblanchon.PDFiumV8.macOS.nuspec
+++ b/nuget/bblanchon.PDFiumV8.macOS.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <copyright>Copyright © Benoit Blanchon 2017-2022</copyright>
+    <copyright>Copyright © Benoit Blanchon 2017-2023</copyright>
     <tags>PDFium PDF binaries library native Chromium</tags>
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>

--- a/nuget/bblanchon.PDFiumV8.macOS.nuspec
+++ b/nuget/bblanchon.PDFiumV8.macOS.nuspec
@@ -7,7 +7,6 @@
     <owners>Benoit Blanchon</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
-    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>

--- a/nuget/bblanchon.PDFiumV8.macOS.nuspec
+++ b/nuget/bblanchon.PDFiumV8.macOS.nuspec
@@ -16,11 +16,20 @@
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFiumV8.macOS.png</iconUrl>
     <readme>README.md</readme>
+
+    <dependencies>
+      <group targetFramework="native" />
+      <group targetFramework="netstandard1.0" />
+    </dependencies>
   </metadata>
 
   <files>
     <file src="bblanchon.PDFiumV8.macOS.png" target="icon.png" />
     <file src="../README.md" target="README.md" />
+
+    <!-- https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5128 -->
+    <file src="_._" target="lib/native/_._" />
+    <file src="_._" target="lib/netstandard1.0/_._" />
 
     <!-- include hearder and lib files for C++ projects -->
     <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFiumV8.macOS.targets" />

--- a/nuget/bblanchon.PDFiumV8.macOS.nuspec
+++ b/nuget/bblanchon.PDFiumV8.macOS.nuspec
@@ -16,10 +16,12 @@
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFiumV8.macOS.png</iconUrl>
+    <readme>README.md</readme>
   </metadata>
 
   <files>
     <file src="bblanchon.PDFiumV8.macOS.png" target="icon.png" />
+    <file src="../README.md" target="README.md" />
 
     <!-- the native PDFium binaries -->
     <!-- see list of available runtime identifiers -->

--- a/nuget/bblanchon.PDFiumV8.nuspec
+++ b/nuget/bblanchon.PDFiumV8.nuspec
@@ -11,7 +11,7 @@
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <copyright>Copyright © Benoit Blanchon 2017-2022</copyright>
+    <copyright>Copyright © Benoit Blanchon 2017-2023</copyright>
     <tags>PDFium PDF binaries library native Chromium</tags>
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>

--- a/nuget/bblanchon.PDFiumV8.nuspec
+++ b/nuget/bblanchon.PDFiumV8.nuspec
@@ -16,6 +16,8 @@
     <repository type="git" url="https://github.com/bblanchon/pdfium-binaries.git" branch="$branch$" commit="$commit$" />
     <icon>icon.png</icon>
     <iconUrl>https://raw.githubusercontent.com/bblanchon/pdfium-binaries/master/nuget/bblanchon.PDFiumV8.png</iconUrl>
+    <readme>README.md</readme>
+    
     <dependencies>
       <group>
         <dependency id="bblanchon.PDFiumV8.Android" version="$version$" />
@@ -30,5 +32,6 @@
   <!-- just a meta package without content -->
   <files>
     <file src="bblanchon.PDFiumV8.png" target="icon.png" />
+    <file src="../README.md" target="README.md" />
   </files>
 </package>

--- a/nuget/bblanchon.PDFiumV8.nuspec
+++ b/nuget/bblanchon.PDFiumV8.nuspec
@@ -7,7 +7,6 @@
     <owners>Benoit Blanchon</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <license type="expression">Apache-2.0</license>
-    <licenseUrl>https://licenses.nuget.org/Apache-2.0</licenseUrl>
     <projectUrl>https://github.com/bblanchon/pdfium-binaries</projectUrl>
     <description>This package contains pre-compiled binaries of the PDFium library, an open-source library for PDF manipulation and rendering.</description>
     <releaseNotes>$releaseNotes$</releaseNotes>


### PR DESCRIPTION
NuGet packages can be consumed by both .NET and C++. And it is possible to create hybrid packages for both. Solves #125.

- For all packages: include header files at `build/native/include/pdfium`
    - The header files are identical between platforms, architechtures and (non-)V8-builds
    - In Visual Studio these are detected automatically via a targets file
-  For Win32 only: include `pdfium.dll.lib` for all architechtures
    - Supported architechtures: `x86`, `x64`, `arm64` and `arm64ec`
    - Matching `pdfium.dll` is copied to output as well
- Added current `README.md` to packages
    - Each NuGet package contains a snapshot of [README.md](https://github.com/bblanchon/pdfium-binaries/blob/master/README.md) at the time of building
    - Fixes [Package authoring best practices: README](https://learn.microsoft.com/en-us/nuget/create-packages/package-authoring-best-practices#readme)
    - Note: img tags are not supported on nuget.org right now (https://github.com/NuGet/NuGetGallery/issues/8644)

Workflow output for these changes: https://github.com/sungaila/pdfium-binaries/actions/runs/6258520023