### PR TITLE
Linux: set `use_allocator_shim` to `false`

### DIFF
--- a/steps/05-configure.sh
+++ b/steps/05-configure.sh
@@ -31,6 +31,9 @@ mkdir -p "$BUILD"
       echo "use_blink = true"
       [ "$ENABLE_V8" == "true" ] && [ "$TARGET_CPU" == "arm64" ] && echo 'arm_control_flow_integrity = "none"'
       ;;
+    linux)
+      echo 'use_allocator_shim = false'
+      ;;
     mac)
       echo 'mac_deployment_target = "10.13.0"'
       ;;


### PR DESCRIPTION
On most platforms, Chrome intercepts and reroutes the `malloc()` / `operator new` symbols (and corresponding `free()` / `delete` and other variants), using the allocator shim. Subsequently, the allocator shim typically directs these symbols to the PartitionAlloc memory allocator.
https://github.com/chromium/chromium/blob/119.0.6019.3/base/allocator/partition_allocator/partition_alloc.gni#L28-L31

Overriding these functions can lead to compatibility issues when being linked against other shared libraries, leading to unexpected behavior or crashes.

Set `use_allocator_shim = false` to disable this behavior.

Resolves #124.