### PR TITLE
Fix musl build

### DIFF
--- a/patches/musl/toolchain.gn
+++ b/patches/musl/toolchain.gn
@@ -11,7 +11,7 @@ gcc_toolchain("x86") {
   ar = "${toolprefix}ar"
   ld = cxx
 
-  extra_cxxflags = "-D_LIBCPP_HAS_MUSL_LIBC"
+  extra_ldflags = "-static-libgcc -static-libstdc++"
 
   toolchain_args = {
     current_cpu = "x86"
@@ -33,7 +33,7 @@ gcc_toolchain("x64") {
   ar = "${toolprefix}ar"
   ld = cxx
 
-  extra_cxxflags = "-D_LIBCPP_HAS_MUSL_LIBC"
+  extra_ldflags = "-static-libgcc -static-libstdc++"
 
   toolchain_args = {
     current_cpu = "x64"


### PR DESCRIPTION
Fixes #129 

This change will produce a musl build that does not have any gcc/glibc symbol imports.
The resulting .so file is quite big (15MB), and I'm not 100% if this is what we're supposed to do.

I have removed the `-D_LIBCPP_HAS_MUSL_LIBC`, because that only has effect when `use_custom_libcxx` is `true`.