### PR TITLE
Disable `allocator_shim` for macOS build

### DIFF
--- a/steps/05-configure.sh
+++ b/steps/05-configure.sh
@@ -35,6 +35,7 @@ mkdir -p "$BUILD"
       echo 'use_allocator_shim = false'
       ;;
     mac)
+      echo 'use_allocator_shim = false'
       echo 'mac_deployment_target = "10.13.0"'
       ;;
     wasm)


### PR DESCRIPTION
When libpdfium is loaded with `dlopen` on macOS this exposes a bug in the `allocator_shim` that causes it to trip over a code assertion when trying to free memory, as a work-around this PR disables the `allocator_shim` for masOS builds to avoid this behavior while the bug is not resolved upstream: https://crbug.com/1271139

Closes: #137 

