### PR TITLE
NuGet: Add target files to Linux and macOS for Mono support

### DIFF
--- a/nuget/bblanchon.PDFium.Linux.nuspec
+++ b/nuget/bblanchon.PDFium.Linux.nuspec
@@ -30,6 +30,11 @@
     <file src="_._" target="lib/native/_._" />
     <file src="_._" target="lib/netstandard1.0/_._" />
 
+    <!-- special targets file copies native binaries for Mono -->
+    <!-- .NET (Core) does not need this and handles the runtimes folder on its own -->
+    <file src="bblanchon.PDFium.Linux.targets" target="build/net461/bblanchon.PDFium.Linux.targets" />
+    <file src="bblanchon.PDFium.Linux.targets" target="buildTransitive/net461/bblanchon.PDFium.Linux.targets" />
+
     <!-- include hearder and lib files for C++ projects -->
     <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFium.Linux.targets" />
     <file src="include/**/*.h" target="build/native" />
@@ -41,6 +46,7 @@
     <file src="pdfium-linux-arm64/lib/libpdfium.so" target="runtimes/linux-arm64/native/libpdfium.so" />
     <file src="pdfium-linux-x64/lib/libpdfium.so" target="runtimes/linux-x64/native/libpdfium.so" />
     <file src="pdfium-linux-x86/lib/libpdfium.so" target="runtimes/linux-x86/native/libpdfium.so" />
+    <file src="pdfium-linux-musl-arm64/lib/libpdfium.so" target="runtimes/linux-musl-arm64/native/libpdfium.so" />
     <file src="pdfium-linux-musl-x64/lib/libpdfium.so" target="runtimes/linux-musl-x64/native/libpdfium.so" />
     <file src="pdfium-linux-musl-x86/lib/libpdfium.so" target="runtimes/linux-musl-x86/native/libpdfium.so" />
   </files>

--- a/nuget/bblanchon.PDFium.Linux.targets
+++ b/nuget/bblanchon.PDFium.Linux.targets
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- this forces .NET Framework targets to copy the native pdfium assemblies -->
+<!-- .NET (Core) supports the runtimes folder out of the box -->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Condition="'$(TargetFramework)'=='net461' or '$(TargetFramework)'=='net462' or '$(TargetFramework)'=='net47' or '$(TargetFramework)'=='net471' or '$(TargetFramework)'=='net472' or '$(TargetFramework)'=='net48' or '$(TargetFramework)'=='net481' or '$(TargetFrameworkVersion)'=='v4.6.1' or '$(TargetFrameworkVersion)'=='v4.6.2' or '$(TargetFrameworkVersion)'=='v4.7' or '$(TargetFrameworkVersion)'=='v4.7.1' or '$(TargetFrameworkVersion)'=='v4.7.2' or '$(TargetFrameworkVersion)'=='v4.8' or '$(TargetFrameworkVersion)'=='v4.8.1'">
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x86\native\libpdfium.so" >
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>x86\libpdfium.so</Link>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-x64\native\libpdfium.so">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>x64\libpdfium.so</Link>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm\native\libpdfium.so">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>arm\libpdfium.so</Link>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-arm64\native\libpdfium.so">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>arm64\libpdfium.so</Link>
+      <Visible>false</Visible>
+    </None>
+
+    <!-- MUSL -->
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-x86\native\libpdfium.so" >
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>musl-x86\libpdfium.so</Link>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-x64\native\libpdfium.so">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>musl-x64\libpdfium.so</Link>
+      <Visible>false</Visible>
+    </None>
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\linux-musl-arm64\native\libpdfium.so">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>musl-arm64\libpdfium.so</Link>
+      <Visible>false</Visible>
+    </None>
+  </ItemGroup>
+</Project>

--- a/nuget/bblanchon.PDFium.macOS.nuspec
+++ b/nuget/bblanchon.PDFium.macOS.nuspec
@@ -30,6 +30,11 @@
     <file src="_._" target="lib/native/_._" />
     <file src="_._" target="lib/netstandard1.0/_._" />
 
+    <!-- special targets file copies native binaries for Mono -->
+    <!-- .NET (Core) does not need this and handles the runtimes folder on its own -->
+    <file src="bblanchon.PDFium.macOS.targets" target="build/net461/bblanchon.PDFium.macOS.targets" />
+    <file src="bblanchon.PDFium.macOS.targets" target="buildTransitive/net461/bblanchon.PDFium.macOS.targets" />
+
     <!-- include hearder and lib files for C++ projects -->
     <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFium.macOS.targets" />
     <file src="include/**/*.h" target="build/native" />

--- a/nuget/bblanchon.PDFium.macOS.targets
+++ b/nuget/bblanchon.PDFium.macOS.targets
@@ -3,7 +3,7 @@
 <!-- .NET (Core) supports the runtimes folder out of the box -->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Condition="'$(TargetFramework)'=='net461' or '$(TargetFramework)'=='net462' or '$(TargetFramework)'=='net47' or '$(TargetFramework)'=='net471' or '$(TargetFramework)'=='net472' or '$(TargetFramework)'=='net48' or '$(TargetFramework)'=='net481' or '$(TargetFrameworkVersion)'=='v4.6.1' or '$(TargetFrameworkVersion)'=='v4.6.2' or '$(TargetFrameworkVersion)'=='v4.7' or '$(TargetFrameworkVersion)'=='v4.7.1' or '$(TargetFrameworkVersion)'=='v4.7.2' or '$(TargetFrameworkVersion)'=='v4.8' or '$(TargetFrameworkVersion)'=='v4.8.1'">
-    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-arm64\native\libpdfium.dylib" >
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-x64\native\libpdfium.dylib" >
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Link>libpdfium.dylib</Link>
       <Visible>false</Visible>

--- a/nuget/bblanchon.PDFium.macOS.targets
+++ b/nuget/bblanchon.PDFium.macOS.targets
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- this forces .NET Framework targets to copy the native pdfium assemblies -->
+<!-- .NET (Core) supports the runtimes folder out of the box -->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Condition="'$(TargetFramework)'=='net461' or '$(TargetFramework)'=='net462' or '$(TargetFramework)'=='net47' or '$(TargetFramework)'=='net471' or '$(TargetFramework)'=='net472' or '$(TargetFramework)'=='net48' or '$(TargetFramework)'=='net481' or '$(TargetFrameworkVersion)'=='v4.6.1' or '$(TargetFrameworkVersion)'=='v4.6.2' or '$(TargetFrameworkVersion)'=='v4.7' or '$(TargetFrameworkVersion)'=='v4.7.1' or '$(TargetFrameworkVersion)'=='v4.7.2' or '$(TargetFrameworkVersion)'=='v4.8' or '$(TargetFrameworkVersion)'=='v4.8.1'">
+    <None Include="$(MSBuildThisFileDirectory)..\..\runtimes\osx-arm64\native\libpdfium.dylib" >
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>libpdfium.dylib</Link>
+      <Visible>false</Visible>
+    </None>
+  </ItemGroup>
+</Project>

--- a/nuget/bblanchon.PDFiumV8.Linux.nuspec
+++ b/nuget/bblanchon.PDFiumV8.Linux.nuspec
@@ -30,6 +30,11 @@
     <file src="_._" target="lib/native/_._" />
     <file src="_._" target="lib/netstandard1.0/_._" />
 
+    <!-- special targets file copies native binaries for Mono -->
+    <!-- .NET (Core) does not need this and handles the runtimes folder on its own -->
+    <file src="bblanchon.PDFium.Linux.targets" target="build/net461/bblanchon.PDFium.Linux.targets" />
+    <file src="bblanchon.PDFium.Linux.targets" target="buildTransitive/net461/bblanchon.PDFium.Linux.targets" />
+
     <!-- include hearder and lib files for C++ projects -->
     <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFiumV8.Linux.targets" />
     <file src="include/**/*.h" target="build/native" />
@@ -41,6 +46,7 @@
     <file src="pdfium-v8-linux-arm64/lib/libpdfium.so" target="runtimes/linux-arm64/native/libpdfium.so" />
     <file src="pdfium-v8-linux-x64/lib/libpdfium.so" target="runtimes/linux-x64/native/libpdfium.so" />
     <file src="pdfium-v8-linux-x86/lib/libpdfium.so" target="runtimes/linux-x86/native/libpdfium.so" />
+    <file src="pdfium-v8-linux-musl-arm64/lib/libpdfium.so" target="runtimes/linux-musl-arm64/native/libpdfium.so" />
     <file src="pdfium-v8-linux-musl-x64/lib/libpdfium.so" target="runtimes/linux-musl-x64/native/libpdfium.so" />
     <file src="pdfium-v8-linux-musl-x86/lib/libpdfium.so" target="runtimes/linux-musl-x86/native/libpdfium.so" />
   </files>

--- a/nuget/bblanchon.PDFiumV8.macOS.nuspec
+++ b/nuget/bblanchon.PDFiumV8.macOS.nuspec
@@ -30,6 +30,11 @@
     <file src="_._" target="lib/native/_._" />
     <file src="_._" target="lib/netstandard1.0/_._" />
 
+    <!-- special targets file copies native binaries for Mono -->
+    <!-- .NET (Core) does not need this and handles the runtimes folder on its own -->
+    <file src="bblanchon.PDFium.macOS.targets" target="build/net461/bblanchon.PDFium.macOS.targets" />
+    <file src="bblanchon.PDFium.macOS.targets" target="buildTransitive/net461/bblanchon.PDFium.macOS.targets" />
+
     <!-- include hearder and lib files for C++ projects -->
     <file src="bblanchon.PDFium.native.targets" target="build/native/bblanchon.PDFiumV8.macOS.targets" />
     <file src="include/**/*.h" target="build/native" />


### PR DESCRIPTION
Right now there is `bblanchon.PDFium.Win32.targets` to copy `pdfium.dll` into the output directory for older .NET Framework projects. This was done for Windows only.

However, there is [Mono](https://www.mono-project.com/) for Windows, Linux and macOS. So there is a need to copy `libpdfium.so` and `libpdfium.dylib` into the output as well.

_Please note that .NET (Core) does not need these target files because it deals with native libs itself._

This PR also adds `pdfium-linux-musl-arm64/lib/libpdfium.so` to the NuGet packages (it contained `linux-musl-x64` and `linux-musl-x86` so far).