### PR TITLE
NuGet: Add release notes to packages

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -555,25 +555,12 @@ jobs:
       - name: Prepare header files
         shell: bash
         run: mkdir -p nuget/include/pdfium && cp -r nuget/pdfium-win-x86/include/* nuget/include/pdfium/
-      - name: Write release notes
-        run: release_notes="This version was built with branch ${{ github.event.inputs.branch }} of PDFium"
-      - name: Get changes
-        continue-on-error: true
-        run: |
-          CURRENT_REV=${{ github.event.inputs.branch }}
-          PREVIOUS_REV=$(curl --silent "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r ".tag_name")
-          git clone -b "${{ github.event.inputs.branch }}" https://pdfium.googlesource.com/pdfium.git
-          cat <<END >> $release_notes
-          
-          Commits between $PREVIOUS_REV and $CURRENT_REV:
-          END
-          git -C "pdfium" log origin/${PREVIOUS_REV}.. --pretty=format:'* %s' >> $release_notes
       - name: Pack
         shell: bash
         run: |
           for NUSPEC in nuget/*.nuspec; do
             echo "::group::$NUSPEC"
-            nuget pack "$NUSPEC" -properties "version=${{ github.event.inputs.version || '0.0.0.0' }};branch=${GITHUB_REF#refs/heads/};commit=${GITHUB_SHA};releaseNotes=$release_notes"
+            nuget pack "$NUSPEC" -properties "version=${{ github.event.inputs.version || '0.0.0.0' }};branch=${GITHUB_REF#refs/heads/};commit=${GITHUB_SHA};releaseNotes=https://github.com/bblanchon/pdfium-binaries/releases/tag/${{ github.event.inputs.branch }}"
             echo "::endgroup::"
           done
       - name: Upload artifact

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -555,12 +555,25 @@ jobs:
       - name: Prepare header files
         shell: bash
         run: mkdir -p nuget/include/pdfium && cp -r nuget/pdfium-win-x86/include/* nuget/include/pdfium/
+      - name: Write release notes
+        run: release_notes="This version was built with branch ${{ github.event.inputs.branch }} of PDFium"
+      - name: Get changes
+        continue-on-error: true
+        run: |
+          CURRENT_REV=${{ github.event.inputs.branch }}
+          PREVIOUS_REV=$(curl --silent "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r ".tag_name")
+          git clone -b "${{ github.event.inputs.branch }}" https://pdfium.googlesource.com/pdfium.git
+          cat <<END >> $release_notes
+          
+          Commits between $PREVIOUS_REV and $CURRENT_REV:
+          END
+          git -C "pdfium" log origin/${PREVIOUS_REV}.. --pretty=format:'* %s' >> $release_notes
       - name: Pack
         shell: bash
         run: |
           for NUSPEC in nuget/*.nuspec; do
             echo "::group::$NUSPEC"
-            nuget pack "$NUSPEC" -properties "version=${{ github.event.inputs.version || '0.0.0.0' }};branch=${GITHUB_REF#refs/heads/};commit=${GITHUB_SHA}"
+            nuget pack "$NUSPEC" -properties "version=${{ github.event.inputs.version || '0.0.0.0' }};branch=${GITHUB_REF#refs/heads/};commit=${GITHUB_SHA};releaseNotes=$release_notes"
             echo "::endgroup::"
           done
       - name: Upload artifact


### PR DESCRIPTION
The GitHub releases have these nice auto-generated release notes containing the chromium branch name and commit messages. It would be great to have these for the NuGet packages, too.

NuGet release notes are plain text and don't support markdown (https://github.com/NuGet/NuGetGallery/issues/8889) so the format and URLs had to be stripped.

I haven't tested this change myself so it would be a good idea to double check if this bash script/workflow yaml looks correct.