### PR TITLE
Small typo fix in build-all.yml

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -563,7 +563,7 @@ jobs:
           VERSION="${{ github.event.inputs.version || '0.0.0.0' }}"
           BRANCH="${GITHUB_REF#refs/heads/}"
           COMMIT="${GITHUB_SHA}"
-          RELEASE_NOTES="${{github.server_url}}/${{github.repository}}/releases/"
+          RELEASE_NOTES="${{github.server_url}}/${{github.repository}}/releases"
           ${{ github.event.inputs.release }} && RELEASE_NOTES+="/tag/${{ github.event.inputs.branch }}"
           echo "NUSPEC_PROPERTIES=version=$VERSION;branch=$BRANCH;commit=$COMMIT;releaseNotes=$RELEASE_NOTES" >> "$GITHUB_ENV"
       - name: Pack

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -557,12 +557,21 @@ jobs:
       - name: Prepare header files
         shell: bash
         run: mkdir -p nuget/include/pdfium && cp -r nuget/pdfium-win-x86/include/* nuget/include/pdfium/
+      - name: Define properties
+        shell: bash
+        run: |
+          VERSION="${{ github.event.inputs.version || '0.0.0.0' }}"
+          BRANCH="${GITHUB_REF#refs/heads/}"
+          COMMIT="${GITHUB_SHA}"
+          RELEASE_NOTES="${{github.server_url}}/${{github.repository}}/releases/"
+          ${{ github.event.inputs.release }} && RELEASE_NOTES+="/tag/${{ github.event.inputs.branch }}"
+          echo "NUSPEC_PROPERTIES=version=$VERSION;branch=$BRANCH;commit=$COMMIT;releaseNotes=$RELEASE_NOTES" >> "$GITHUB_ENV"
       - name: Pack
         shell: bash
         run: |
           for NUSPEC in nuget/*.nuspec; do
             echo "::group::$NUSPEC"
-            nuget pack "$NUSPEC" -properties "version=${{ github.event.inputs.version || '0.0.0.0' }};branch=${GITHUB_REF#refs/heads/};commit=${GITHUB_SHA}"
+            nuget pack "$NUSPEC" -p "$NUSPEC_PROPERTIES"
             echo "::endgroup::"
           done
       - name: Upload artifact


### PR DESCRIPTION
The NuGet release notes use one slash too many for the URL. It would result in
`https://github.com/bblanchon/pdfium-binaries/releases//tag/chromium%2F6259`
instead of
`https://github.com/bblanchon/pdfium-binaries/releases/tag/chromium%2F6259`.

Though the URL https://github.com/bblanchon/pdfium-binaries/releases//tag/chromium%2F6259 still works.