### PR TITLE
Add support for Android API 21+

### DIFF
--- a/patches/PDFiumConfig.cmake
+++ b/patches/PDFiumConfig.cmake
@@ -17,6 +17,7 @@ find_path(PDFium_INCLUDE_DIR
 )
 
 set(PDFium_VERSION "#VERSION#")
+set(PDFium_LIBRARY_NAME "#LIBRARY_NAME#")
 
 if(WIN32)
   find_file(PDFium_LIBRARY
@@ -43,7 +44,7 @@ if(WIN32)
   )
 else()
   find_library(PDFium_LIBRARY
-        NAMES "pdfium"
+        NAMES "${PDFium_LIBRARY_NAME}"
         PATHS "${CMAKE_CURRENT_LIST_DIR}"
         PATH_SUFFIXES "lib")
 

--- a/patches/android/build.patch
+++ b/patches/android/build.patch
@@ -1,13 +1,16 @@
 diff --git a/config/BUILDCONFIG.gn b/config/BUILDCONFIG.gn
-index 105e194..50499f6 100644
+index 26a23e459..b7517c4b2 100644
 --- a/config/BUILDCONFIG.gn
 +++ b/config/BUILDCONFIG.gn
-@@ -479,6 +479,9 @@ if (is_fuchsia) {
+@@ -480,6 +480,12 @@ if (is_fuchsia) {
  }
  set_defaults("shared_library") {
    configs = default_shared_library_configs
 +  if (is_android) {
 +    configs -= [ "//build/config/android:hide_all_but_jni_onload" ]
++    # By appending .cr, we prevent name collisions with libraries already
++    # loaded by the Android zygote. (Required for Android API 21-22)
++    output_extension = "cr.so"
 +  }
  }
  set_defaults("loadable_module") {

--- a/steps/05-configure.sh
+++ b/steps/05-configure.sh
@@ -29,6 +29,7 @@ mkdir -p "$BUILD"
   case "$OS" in
     android)
       echo "clang_use_chrome_plugins = false"
+      echo "default_min_sdk_version = 21"
       ;;
     ios)
       echo "ios_enable_code_signing = false"

--- a/steps/07-stage.sh
+++ b/steps/07-stage.sh
@@ -3,6 +3,7 @@
 IS_DEBUG=${PDFium_IS_DEBUG:-false}
 OS=${PDFium_TARGET_OS:?}
 VERSION=${PDFium_VERSION:-}
+LIBRARY_NAME="pdfium"
 PATCHES="$PWD/patches"
 
 SOURCE=${PDFium_SOURCE_DIR:-pdfium}
@@ -12,10 +13,9 @@ STAGING="$PWD/staging"
 STAGING_BIN="$STAGING/bin"
 STAGING_LIB="$STAGING/lib"
 
+rm -rf "$STAGING"
 mkdir -p "$STAGING"
 mkdir -p "$STAGING_LIB"
-
-sed "s/#VERSION#/${VERSION:-0.0.0.0}/" <"$PATCHES/PDFiumConfig.cmake" >"$STAGING/PDFiumConfig.cmake"
 
 cp "$SOURCE/LICENSES" "$STAGING/LICENSE"
 cp "$BUILD/args.gn" "$STAGING"
@@ -25,7 +25,12 @@ rm -f "$STAGING/include/README"
 rm -f "$STAGING/include/PRESUBMIT.py"
 
 case "$OS" in
-  android|linux)
+  android)
+    mv "$BUILD/libpdfium.cr.so" "$STAGING_LIB"
+    LIBRARY_NAME="pdfium.cr"
+    ;;
+
+  linux)
     mv "$BUILD/libpdfium.so" "$STAGING_LIB"
     ;;
 
@@ -48,6 +53,8 @@ case "$OS" in
     [ "$IS_DEBUG" == "true" ] && mv "$BUILD/pdfium.dll.pdb" "$STAGING_BIN"
     ;;
 esac
+
+cat "$PATCHES/PDFiumConfig.cmake" | sed "s/#VERSION#/${VERSION:-0.0.0.0}/" | sed "s/#LIBRARY_NAME#/${LIBRARY_NAME}/" > "$STAGING/PDFiumConfig.cmake"
 
 if [ -n "$VERSION" ]; then
   cat >"$STAGING/VERSION" <<END


### PR DESCRIPTION
To make it work on Android 21+, we need following changes:

1) Change `default_min_sdk_version`, by default **pdfium** uses **26** for this variable, but we can set it to **21**. This is actually lowest supported sdk version by **pdfuim** controlled by `min_supported_sdk_version` (see [pdfium/build/config/android/config.gni:90](https://chromium.googlesource.com/chromium/src/+/3afb48e498491b225dd48dff583f24d35e044141/build/config/android/config.gni#90))

2) Change library `soname` to avoid conflict with system **pdfium** library.
    Due to the linker bug on older Android API levels (which was fixed in API 23+ [Correct soname/path handling (Available in API level >= 23)](https://android.googlesource.com/platform/bionic/+/5067ef29d4f4e5a7f589dc5c4c362621c2523da0/android-changes-for-ndk-developers.md#correct-soname_path-handling-available-in-api-level-23)
    System linker prefers already loaded `/system/lib/libpdfium.so` library instead of our library when making symbol resolution. That why you can receive such errors https://github.com/bblanchon/pdfium-binaries/issues/147#issuecomment-1837542975
    ```
    For Android 21-22 i received error "UnsatisfiedLinkError: dlopen failed: cannot locate symbol "FPDFBookmark_GetFirstChild" referenced"
    ```
    To mitigate this problem we need to change library `soname`, by changing `output_extension` variable to `cr.so` for example (it will produce `libpdfium.cr.so`), this variable then used in  [pdfium/build/toolchain/gcc_toolchain.gni:448](https://gn.googlesource.com/gn/+/e375226345b2be2bfc8c4549702ee3e437b5c136/build/toolchain/gcc_toolchain.gni?pli=1#458) to set `soname`.

Fixes #147