### PR TITLE
macOS: allow install_name_tool -id to work

### DIFF
--- a/patches/mac/build.patch
+++ b/patches/mac/build.patch
@@ -1,0 +1,21 @@
+diff --git a/toolchain/apple/toolchain.gni b/toolchain/apple/toolchain.gni
+index ec3b67a..c0beb8c 100644
+--- a/toolchain/apple/toolchain.gni
++++ b/toolchain/apple/toolchain.gni
+@@ -502,6 +502,16 @@ template("single_apple_toolchain") {
+       nm = "${prefix}llvm-nm"
+       otool = "${prefix}llvm-otool"
+ 
++      # Give room to set the soname equivalent path in the resulting output.
++      # Required for usage in nixpkgs (as they set the LC_ID_DYLIB to a path in
++      # /nix/store).
++      #
++      # Refused by Chromium in
++      # https://groups.google.com/g/pdfium/c/72lDbDSQric/m/Eq7VgkPZDwAJ due to
++      # it not making sense in their context to be able to patch binary
++      # headers.
++      linker_driver_args += " -Wl,-headerpad_max_install_names"
++
+       link_command = "$linker_driver_env $linker_driver"
+       link_command += " -Wcrl,otoolpath,$otool -Wcrl,nmpath,$nm"
+       link_command += " -Wcrl,tocname,\"$tocname\""

--- a/steps/03-patch.sh
+++ b/steps/03-patch.sh
@@ -29,6 +29,10 @@ case "$OS" in
     [ "$ENABLE_V8" == "true" ] && apply_patch "$PATCHES/ios/v8.patch" v8
     ;;
 
+  mac)
+    apply_patch "$PATCHES/mac/build.patch" build
+    ;;
+
   linux)
     [ "$ENABLE_V8" == "true" ] && apply_patch "$PATCHES/linux/v8.patch" v8
     ;;


### PR DESCRIPTION
This is required so that LC_ID_DYLIB may be set using install_name_tool by downstream consumers. What the LC_ID_DYLIB field does is that when the dylib is given to the linker, it forms the path the dylib in question will be referred to in the RPATH of the resulting dependent dylibs/executables.

Fixes: https://github.com/bblanchon/pdfium-binaries/issues/198

This is necessary to support nixpkgs which wants to set this field to /nix/store/..., but hits an error if we try doing that due to lack of padding in the executable header (requiring relinking upstream, which, hi!).

```
       > /nix/store/9n1n53pyrjdanm5gsxcgchr9v0i0401v-pdfium-lib/lib/libpdfium.dylib: fixing dylib
       > error: install_name_tool: changing install names or rpaths can't be redone for: /nix/store/9n1n53pyrjdanm5gsxcgchr9v0i0401v-p
dfium-lib/lib/libpdfium.dylib (for architecture arm64) because larger updated load commands do not fit (the program must be relinked, 
and you may need to use -headerpad or -headerpad_max_install_names)
```