### PR TITLE
WIP: build with is_asan=true for humanpred/rpdfium#44 triage

### DIFF
--- a/steps/05-configure.sh
+++ b/steps/05-configure.sh
@@ -15,6 +15,11 @@ mkdir -p "$BUILD"
   echo "is_debug = $IS_DEBUG"
   echo "pdf_is_standalone = true"
   echo "pdf_use_partition_alloc = false"
+  # AddressSanitizer build, for triaging humanpred/rpdfium#44.
+  # is_lsan needs PartitionAlloc which we explicitly disable
+  # above; setting it to false avoids a gn dependency error.
+  echo "is_asan = true"
+  echo "is_lsan = false"
   echo "target_cpu = \"$TARGET_CPU\""
   echo "target_os = \"$OS\""
   echo "pdf_enable_v8 = $ENABLE_V8"


### PR DESCRIPTION
rpdfium on macOS arm64 R 4.6.0 segfaults at address 0x656e6e75722f7372 ('rs/runne' = mid-/Users/runner/) inside cpp_struct_tree_page → R_GetCCallable → get_package_CEntry_table. ASan/UBSan on Linux through 2996 testthat tests is clean; the crash is not reproducible on Linux even with valgrind. So the bug lives in PDFium's macOS-arm64-specific path (CoreText / GCD) or in its system-library interactions — both invisible without ASan-built libpdfium for mac-arm64.

This branch adds `is_asan = true` + `is_lsan = false` to args.gn so the next `build-one` workflow run produces an ASan-instrumented libpdfium.dylib. Drop that into rpdfium's inst/pdfium-binaries/ and the next macos-latest CI run will fire global-buffer-overflow on the wild write that corrupts R's static CEntryTable.

Not for upstream — local triage only.