### PR TITLE
Avoid direct template expansion in run blocks

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -636,12 +636,13 @@ jobs:
           VERSION="$VERSION"
           BRANCH="${GITHUB_REF#refs/heads/}"
           COMMIT="${GITHUB_SHA}"
-          RELEASE_NOTES="${{github.server_url}}/${{github.repository}}/releases"
+          RELEASE_NOTES="${RELEASE_PREFIX}/releases"
           $RELEASE && RELEASE_NOTES+="/tag/$BRANCH"
           echo "NUSPEC_PROPERTIES=version=$VERSION;branch=$BRANCH;commit=$COMMIT;releaseNotes=$RELEASE_NOTES" >> "$GITHUB_ENV"
         env:
           VERSION: ${{ github.event.inputs.version || '0.0.0.0' }}
           RELEASE: ${{ github.event.inputs.release }}
+          RELEASE_PREFIX: ${{ format('{0}/{1}', github.server_url, github.repository) }}
           BRANCH: ${{ github.event.inputs.branch }}
       - name: Pack
         shell: bash
@@ -658,7 +659,7 @@ jobs:
           path: '*.nupkg'
       - name: Push to nuget.org
         if: env.NUGET_API_KEY && startsWith(github.event.inputs.branch, 'chromium/') && github.event.inputs.version && github.event.inputs.nuget == 'true'
-        run: nuget push -Source nuget.org -ApiKey ${{ secrets.NUGET_API_KEY }} *.nupkg
+        run: nuget push -Source nuget.org -ApiKey "$NUGET_API_KEY" *.nupkg
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY  }}
 
@@ -801,7 +802,7 @@ jobs:
         continue-on-error: true
         run: |
           CURRENT_REV=$BRANCH
-          PREVIOUS_REV=$(curl --silent "https://api.github.com/repos/${{ github.repository }}/releases/latest" | jq -r ".tag_name")
+          PREVIOUS_REV=$(curl --silent "https://api.github.com/repos/$REPO_NAME/releases/latest" | jq -r ".tag_name")
           git clone -b "$BRANCH" https://pdfium.googlesource.com/pdfium.git
           cat <<END >> RELEASE.md
           ### Changes
@@ -809,6 +810,7 @@ jobs:
           END
           git -C "pdfium" log origin/${PREVIOUS_REV}.. --pretty=format:'* [%s](https://pdfium.googlesource.com/pdfium/+/%H)' >> RELEASE.md
         env:
+          REPO_NAME: ${{ github.repository }}
           BRANCH: ${{ github.event.inputs.branch }}
       - name: Generate artifacts checksums
         id: hash
@@ -819,7 +821,9 @@ jobs:
         with:
           subject-path: pdfium-*.tgz
       - name: Rename provenance file
-        run: mv "${{ steps.provenance.outputs.bundle-path }}" pdfium-attestation.json
+        run: mv "$BUNDLE_PATH" pdfium-attestation.json
+        env:
+          BUNDLE_PATH: ${{ steps.provenance.outputs.bundle-path }}
       - name: Publish Release
         uses: ncipollo/release-action@v1
         with:

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -802,7 +802,7 @@ jobs:
         continue-on-error: true
         run: |
           CURRENT_REV=$BRANCH
-          PREVIOUS_REV=$(curl --silent "https://api.github.com/repos/$REPO_NAME/releases/latest" | jq -r ".tag_name")
+          PREVIOUS_REV=$(curl --silent "https://api.github.com/repos/$REPOSITORY/releases/latest" | jq -r ".tag_name")
           git clone -b "$BRANCH" https://pdfium.googlesource.com/pdfium.git
           cat <<END >> RELEASE.md
           ### Changes
@@ -810,7 +810,7 @@ jobs:
           END
           git -C "pdfium" log origin/${PREVIOUS_REV}.. --pretty=format:'* [%s](https://pdfium.googlesource.com/pdfium/+/%H)' >> RELEASE.md
         env:
-          REPO_NAME: ${{ github.repository }}
+          REPOSITORY: ${{ github.repository }}
           BRANCH: ${{ github.event.inputs.branch }}
       - name: Generate artifacts checksums
         id: hash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,8 +75,10 @@ jobs:
           [ "$PDFium_TARGET_OS" != "emscripten" ] && ARTIFACT="$ARTIFACT-$PDFium_TARGET_OS"
           [ "$PDFium_TARGET_ENVIRONMENT" != "" ] && ARTIFACT="$ARTIFACT-$PDFium_TARGET_ENVIRONMENT"
           ARTIFACT="$ARTIFACT-$PDFium_TARGET_CPU"
-          [ "${{inputs.is_debug}}" == "true" ] && ARTIFACT="$ARTIFACT-debug"
+          [ "$INPUTS_IS_DEBUG" == "true" ] && ARTIFACT="$ARTIFACT-debug"
           echo "artifact=$ARTIFACT" >> $GITHUB_OUTPUT
+        env:
+          INPUTS_IS_DEBUG: ${{ inputs.is_debug }}
       - name: Checkout this repo
         uses: actions/checkout@v6
       - name: Set environment variables

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -86,10 +86,15 @@ jobs:
         run: |
           {
             echo "## Rejected patches";
-            echo "The following patches for the configuration ${{ matrix.os }} ${{ matrix.cpu }} ${{ matrix.v8 && 'v8' || '' }} ${{ matrix.environment || '' }} were rejected:";
+            echo "The following patches for the configuration $MATRIX_OS $MATRIX_CPU $MATRIX_V8 $MATRIX_ENVIRONMENT were rejected:";
             find pdfium -name '*.rej' -type f \
               -printf '### `%P`\n```patch\n' \
               -exec cat {} \; \
               -printf '```\n' || \
               echo 'No .rej files found';
           } >> $GITHUB_STEP_SUMMARY
+        env:
+          MATRIX_OS: ${{ matrix.os }}
+          MATRIX_CPU: ${{ matrix.cpu }}
+          MATRIX_V8: ${{ matrix.v8 && 'v8' || '' }}
+          MATRIX_ENVIRONMENT: ${{ matrix.environment || '' }}


### PR DESCRIPTION
This addresses some findings from `zizmor .github/ --persona auditor`
See also https://docs.zizmor.sh/audits/#template-injection
> [...] zizmor considers all template expansions in code contexts to be code smells, [even ones that are likely safe,] and attempting to selectively permit them is more error-prone than forbidding them in a blanket fashion.

Disclaimer: Untested