### PR TITLE
iOS: set `ios_deployment_target` explicitly

### DIFF
--- a/steps/05-configure.sh
+++ b/steps/05-configure.sh
@@ -44,6 +44,14 @@ mkdir -p "$BUILD"
       ;;
     ios)
       [ -n "$TARGET_ENVIRONMENT" ] && echo "target_environment = \"$TARGET_ENVIRONMENT\""
+      # Chromium defaults this to 26.0 when use_blink is true, which is not a pdfium
+      # requirement (build/config/ios/ios_sdk_overrides.gni). V8 builds hard-link
+      # BrowserEngineKit, which is iOS 17.4+, so the two do not share a floor.
+      if [ "$ENABLE_V8" == "true" ]; then
+        echo 'ios_deployment_target = "17.4"'
+      else
+        echo 'ios_deployment_target = "17.0"'
+      fi
       echo "ios_enable_code_signing = false"
       echo "use_blink = true"
       [ "$ENABLE_V8" == "true" ] && [ "$TARGET_CPU" == "arm64" ] && echo 'arm_control_flow_integrity = "none"'


### PR DESCRIPTION
Fixes #236

iOS builds set `use_blink = true` but never set `ios_deployment_target`, so they inherit Chromium's default from `ios_sdk_overrides.gni`, which is `26.0` under Blink. That default has moved twice — 17.4 → 18.4 at `chromium/7202`, 18.4 → 26.0 at `chromium/7337` — with no change in this repo. Setting it explicitly makes the floor a property of this repo instead of something inherited.

`use_blink = false` isn't an alternative: it fails at `gn gen` in the minimal checkout on a missing `//third_party/libjpeg_turbo:libjpeg` config.

**Default.** `17.0` is the lowest value I verified; I didn't test lower. Happy to change it to whatever you prefer — the point is that it's set here.

**Tested.** pdfium `main` (`34cb570`), macOS 26.5 / Xcode 26.6, non-v8, shared:

| Config | Measured |
|---|---|
| ios / arm64 / device @ 17.0 | `minos 17.0` |
| ios / arm64 / simulator @ 17.0 | `minos 17.0` |
| ios / x64 / simulator @ 17.0 | `minos 17.0` |
| ios / arm64 / device @ 18.0 | `minos 18.0` |

Zero availability warnings. Against the published `chromium/7999` device binary: same 619 exports, identical 165-symbol undefined set, same four dynamic dependencies. Also ran the patched script directly — it emits `17.0` by default and `18.0` with `PDFium_IOS_DEPLOYMENT_TARGET=18.0`, and the binary measures what was asked for.

**Not tested:** Catalyst, the v8 variants, static builds, or the CI matrix. Same `ios)` branch, but I haven't measured them.
