### PR TITLE
Fix static macOS/iOS builds: use system libc++ and link required Apple frameworks

### DIFF
--- a/patches/PDFiumStaticConfig.cmake
+++ b/patches/PDFiumStaticConfig.cmake
@@ -50,6 +50,17 @@ else()
     IMPORTED_LINK_INTERFACE_LANGUAGES "CXX"
   )
 
+  # A shared build resolves these itself; a static archive leaves them to the
+  # consumer, so linking fails on _CFRelease, _CGBitmapContextCreate and
+  # friends without them.
+  if(APPLE)
+    set_property(TARGET pdfium APPEND PROPERTY
+      INTERFACE_LINK_LIBRARIES
+        "-framework CoreFoundation"
+        "-framework CoreGraphics"
+    )
+  endif()
+
   find_package_handle_standard_args(PDFium
     REQUIRED_VARS PDFium_LIBRARY PDFium_INCLUDE_DIR
     VERSION_VAR PDFium_VERSION

--- a/steps/05-configure.sh
+++ b/steps/05-configure.sh
@@ -30,18 +30,16 @@ mkdir -p "$BUILD"
   if [ "$BUILD_TYPE" == "static" ]; then
     echo "pdf_is_complete_lib = true"
 
+    # Chromium's bundled libc++ is only a dependency of executables, shared
+    # libraries and loadable modules (see //build/config/BUILDCONFIG.gn), never
+    # of a static_library, so its compiled objects don't make it into
+    # libpdfium.a. Its symbols also carry the __Cr ABI namespace, which no
+    # platform C++ library provides, so the consumer's link fails on undefined
+    # std::__Cr::ios_base as soon as pdfium's FDF code is pulled in.
+    echo "use_custom_libcxx = false"
+
     if [ "$OS-$TARGET_CPU" == "linux-arm64" ]; then
       echo "use_lld = false"
-      echo "use_custom_libcxx = false"
-    fi
-
-    # A static archive is linked into the consumer's binary, which uses the
-    # platform libc++. Chromium's bundled libc++ mangles as std::__Cr and its
-    # compiled iostream objects are not part of the archive, so linking fails on
-    # undefined std::__Cr::ios_base symbols as soon as pdfium's FDF code is
-    # pulled in. Build against the system libc++ (std::__1) instead.
-    if [ "$OS" == "ios" ] || [ "$OS" == "mac" ]; then
-      echo "use_custom_libcxx = false"
     fi
   fi
 

--- a/steps/05-configure.sh
+++ b/steps/05-configure.sh
@@ -34,6 +34,15 @@ mkdir -p "$BUILD"
       echo "use_lld = false"
       echo "use_custom_libcxx = false"
     fi
+
+    # A static archive is linked into the consumer's binary, which uses the
+    # platform libc++. Chromium's bundled libc++ mangles as std::__Cr and its
+    # compiled iostream objects are not part of the archive, so linking fails on
+    # undefined std::__Cr::ios_base symbols as soon as pdfium's FDF code is
+    # pulled in. Build against the system libc++ (std::__1) instead.
+    if [ "$OS" == "ios" ] || [ "$OS" == "mac" ]; then
+      echo "use_custom_libcxx = false"
+    fi
   fi
 
   case "$OS" in


### PR DESCRIPTION
Partially solves https://github.com/bblanchon/pdfium-binaries/issues/223

`build.sh -s mac` / `build.sh -s ios` currently produce an archive that can't be linked against:

- Chromium's bundled libc++ mangles as `std::__Cr` and its compiled iostream objects aren't in the archive, so linking fails with undefined `std::__Cr::ios_base` symbols once pdfium's FDF code is pulled in.
- A shared build resolves CoreFoundation and CoreGraphics itself; a static archive leaves them to the consumer, so `steps/09-test.sh` fails on undefined `_CFRelease`, `_CGBitmapContextCreate` and similar.

Both fixes are scoped to static builds; shared builds are unaffected.