### PR TITLE
Ship libpdfium.a and the C++ headers in the WebAssembly package

### DIFF
--- a/steps/07-stage.sh
+++ b/steps/07-stage.sh
@@ -56,7 +56,7 @@ case "$OS-$BUILD_TYPE" in
     mv "$BUILD/pdfium.html" "$STAGING_LIB"
     mv "$BUILD/pdfium.js" "$STAGING_LIB"
     mv "$BUILD/pdfium.wasm" "$STAGING_LIB"
-    rm -rf "$STAGING/include/cpp"
+    mv "$BUILD/obj/libpdfium.a" "$STAGING_LIB"
     rm "$STAGING/PDFiumConfig.cmake"
     ;;
 


### PR DESCRIPTION
The emscripten configuration already builds with pdf_is_complete_lib, but the package only carries the prebuilt pdfium.js/.wasm module, and the C++ headers are deleted. Consumers who need to expose APIs the prebuilt module does not export have to rebuild pdfium from source to get an archive to link against.

Ship the archive and keep include/cpp so they can compile their own glue and emit their own module from the published package.